### PR TITLE
Remove 'near ground', fix landing anim lag

### DIFF
--- a/workers/unity/Assets/Fps/Art/AnimationControllers/FirstPersonAnims.controller
+++ b/workers/unity/Assets/Fps/Art/AnimationControllers/FirstPersonAnims.controller
@@ -26,12 +26,6 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
-  - m_Name: NearGround
-    m_Type: 4
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 0}
   - m_Name: Movement
     m_Type: 1
     m_DefaultFloat: 0

--- a/workers/unity/Assets/Fps/Art/AnimationControllers/ThirdPersonAnims.controller
+++ b/workers/unity/Assets/Fps/Art/AnimationControllers/ThirdPersonAnims.controller
@@ -13,43 +13,43 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Pitch
     m_Type: 1
     m_DefaultFloat: -90
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Grounded
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: X
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Z
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Movement
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Sprinting
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base
@@ -720,22 +720,49 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &1101420971358438898
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Grounded
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102233534925507944}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &1101485113595726038
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Grounded
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1102544389727780834}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.2
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.4
+  m_ExitTime: 1
   m_HasExitTime: 1
   m_HasFixedDuration: 0
   m_InterruptionSource: 0
@@ -1081,6 +1108,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1101485113595726038}
+  - {fileID: 1101420971358438898}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -1178,13 +1206,13 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 1102544389727780834}
-    m_Position: {x: 288, y: 276, z: 0}
+    m_Position: {x: 384, y: 288, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102233534925507944}
     m_Position: {x: 168, y: 228, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102564331473817460}
-    m_Position: {x: 396, y: 324, z: 0}
+    m_Position: {x: 600, y: 228, z: 0}
   m_ChildStateMachines:
   - serializedVersion: 1
     m_StateMachine: {fileID: 1107648931561696196}

--- a/workers/unity/Assets/Fps/Art/AnimationControllers/ThirdPersonAnims.controller
+++ b/workers/unity/Assets/Fps/Art/AnimationControllers/ThirdPersonAnims.controller
@@ -13,49 +13,43 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Pitch
     m_Type: 1
     m_DefaultFloat: -90
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Grounded
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  - m_Name: NearGround
-    m_Type: 4
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: X
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Z
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Movement
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Sprinting
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base
@@ -663,10 +657,7 @@ AnimatorStateTransition:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 3
-    m_ConditionEvent: Movement
-    m_EventTreshold: 0.1
+  m_Conditions: []
   m_DstStateMachine: {fileID: 1107648931561696196}
   m_DstState: {fileID: 0}
   m_Solo: 0
@@ -675,11 +666,11 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0.1
   m_TransitionOffset: 0
-  m_ExitTime: 0.60526323
+  m_ExitTime: 0.32
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
-  m_OrderedInterruption: 1
+  m_OrderedInterruption: 0
   m_CanTransitionToSelf: 1
 --- !u!1101 &1101097910787203112
 AnimatorStateTransition:
@@ -735,21 +726,18 @@ AnimatorStateTransition:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 2
-    m_ConditionEvent: NearGround
-    m_EventTreshold: 0
+  m_Conditions: []
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1102544389727780834}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0.2
   m_TransitionOffset: 0
-  m_ExitTime: 0.7321429
+  m_ExitTime: 0.4
   m_HasExitTime: 1
-  m_HasFixedDuration: 1
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
@@ -894,30 +882,6 @@ AnimatorStateTransition:
   m_ExitTime: 0
   m_HasExitTime: 0
   m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &1101744463204969500
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: Grounded
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 1102233534925507944}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0.5
-  m_HasExitTime: 1
-  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
@@ -1117,7 +1081,6 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1101485113595726038}
-  - {fileID: 1101744463204969500}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -1215,13 +1178,13 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 1102544389727780834}
-    m_Position: {x: 384, y: 300, z: 0}
+    m_Position: {x: 288, y: 276, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102233534925507944}
     m_Position: {x: 168, y: 228, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102564331473817460}
-    m_Position: {x: 576, y: 228, z: 0}
+    m_Position: {x: 396, y: 324, z: 0}
   m_ChildStateMachines:
   - serializedVersion: 1
     m_StateMachine: {fileID: 1107648931561696196}

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/Animation/FpsAnimator.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/Animation/FpsAnimator.cs
@@ -50,9 +50,6 @@ namespace Fps
         private readonly AnimationBoolParameter groundedParameter = new AnimationBoolParameter { Name = "Grounded" };
         private readonly AnimationBoolParameter sprintingParameter = new AnimationBoolParameter { Name = "Sprinting" };
 
-        private readonly AnimationBoolParameter
-            nearGroundParameter = new AnimationBoolParameter { Name = "NearGround" };
-
         private const string JumpParameter = "Jump";
         private readonly AnimationFloatParameter movementParameter = new AnimationFloatParameter { Name = "Movement" };
         private readonly AnimationFloatParameter pitchParameter = new AnimationFloatParameter { Name = "Pitch" };
@@ -80,11 +77,6 @@ namespace Fps
         public void SetGrounded(bool grounded)
         {
             SetBoolParameter(groundedParameter, grounded);
-        }
-
-        public void SetNearGround(bool nearGround)
-        {
-            SetBoolParameter(nearGroundParameter, nearGround);
         }
 
         public void SetPitch(float pitch)

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/Animation/ProxyAnimation.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/Animation/ProxyAnimation.cs
@@ -44,7 +44,6 @@ namespace Fps
         private void Update()
         {
             fpsAnimator.SetGrounded(groundChecker.Grounded);
-            fpsAnimator.SetNearGround(groundChecker.NearGround);
             if (isMoving)
             {
                 movementTimeout -= Time.deltaTime;

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/FpsDriver.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/FpsDriver.cs
@@ -187,7 +187,6 @@ namespace Fps
         {
             fpsAnimator.SetAiming(gunState.Data.IsAiming);
             fpsAnimator.SetGrounded(groundChecker.Grounded);
-            fpsAnimator.SetNearGround(groundChecker.NearGround);
             fpsAnimator.SetMovement(transform.position, Time.deltaTime);
             fpsAnimator.SetPitch(pitchTransform.transform.localEulerAngles.x);
 

--- a/workers/unity/Packages/com.improbable.gdk.movement/Behaviours/GroundChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.movement/Behaviours/GroundChecker.cs
@@ -10,12 +10,9 @@ namespace Improbable.Gdk.Movement
         [SerializeField] private LayerMask walkableLayer = ~0;
 
         private CharacterController characterController;
-        private bool nearGround;
         private bool grounded;
 
         public bool OverrideInAir { get; set; }
-        
-        public bool NearGround => nearGround || characterController.isGrounded;
 
         public bool Grounded => grounded || characterController.isGrounded;
 
@@ -29,9 +26,9 @@ namespace Improbable.Gdk.Movement
         {
             var upOffset = characterController.radius + 0.1f;
             var ray = new Ray(transform.position + Vector3.up * upOffset, Vector3.down);
-            nearGround = Physics.SphereCast(ray, characterController.radius, out var hitInfo,
+            var hit = Physics.SphereCast(ray, characterController.radius, out var hitInfo,
                 nearToGroundDistance + upOffset, walkableLayer);
-            grounded = nearGround && hitInfo.distance < upOffset + 0.1f;
+            grounded = hit && hitInfo.distance < upOffset + 0.1f;
         }
     }
 }


### PR DESCRIPTION
#### Description
- Remove the 'near ground state', since it is mostly unused.
- Reduce the jumping anim length, to fix the pauses upon landing
(To note, jumping onto and walking off small blocks looks a bit weird. We should probably check that that looks alright before pushing this in)