### PR TITLE
remove all bullets if player disabled/removed

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.guns/Behaviours/ShotRenderer.cs
+++ b/workers/unity/Packages/com.improbable.gdk.guns/Behaviours/ShotRenderer.cs
@@ -64,6 +64,18 @@ namespace Improbable.Gdk.Guns
             shooting.OnShots += ShotFired;
         }
 
+        private void OnDisable()
+        {
+            StopAllCoroutines();
+
+            foreach (var bullet in activeBulletDetails.Keys)
+            {
+                bullet.ReturnToPool();
+            }
+
+            activeBulletDetails.Clear();
+        }
+
         private void ShotFired(ShotInfo shotInfo)
         {
             var isAiming = gunState.Data.IsAiming;
@@ -196,11 +208,11 @@ namespace Improbable.Gdk.Guns
                     var startValue = bulletDetails.Start / barrelLerpThreshold;
                     startValue = Mathf.Clamp(startValue, 0, 1);
                     lineRenderer.SetPosition(0,
-                        Vector3.Lerp(GunBarrel.position + GunBarrel.forward * bulletDetails.Start, lineRenderer.GetPosition(0),
-                            startValue));
+                        Vector3.Lerp(GunBarrel.position + GunBarrel.forward * bulletDetails.Start,
+                            lineRenderer.GetPosition(0),   startValue));
                     lineRenderer.SetPosition(1,
-                        Vector3.Lerp(GunBarrel.position + GunBarrel.forward * bulletDetails.End, lineRenderer.GetPosition(1),
-                            startValue));
+                        Vector3.Lerp(GunBarrel.position + GunBarrel.forward * bulletDetails.End,
+                            lineRenderer.GetPosition(1), startValue));
                 }
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.guns/Behaviours/ShotRenderer.cs
+++ b/workers/unity/Packages/com.improbable.gdk.guns/Behaviours/ShotRenderer.cs
@@ -66,8 +66,6 @@ namespace Improbable.Gdk.Guns
 
         private void OnDisable()
         {
-            StopAllCoroutines();
-
             foreach (var bullet in activeBulletDetails.Keys)
             {
                 bullet.ReturnToPool();
@@ -209,7 +207,7 @@ namespace Improbable.Gdk.Guns
                     startValue = Mathf.Clamp(startValue, 0, 1);
                     lineRenderer.SetPosition(0,
                         Vector3.Lerp(GunBarrel.position + GunBarrel.forward * bulletDetails.Start,
-                            lineRenderer.GetPosition(0),   startValue));
+                            lineRenderer.GetPosition(0), startValue));
                     lineRenderer.SetPosition(1,
                         Vector3.Lerp(GunBarrel.position + GunBarrel.forward * bulletDetails.End,
                             lineRenderer.GetPosition(1), startValue));


### PR DESCRIPTION
#### Description
A tentative bug fix for some linerenderers remaining in the world. (Coroutines are stopped, so if a player is removed, their existing bullets would not be sent back to the pool)
This hasn't been tested in a deployment yet.