### PR TITLE
Change the forced rotation a player receives on respawn, from a comma…

### DIFF
--- a/workers/unity/Assets/Fps/Scripts/GameLogic/FpsDriver.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/FpsDriver.cs
@@ -60,7 +60,7 @@ namespace Fps
         {
             Cursor.lockState = CursorLockMode.Locked;
             Cursor.visible = false;
-            serverMovement.OnForcedRotation += OnForcedRotaiton;
+            serverMovement.OnForcedRotation += OnForcedRotation;
         }
 
         private void Update()
@@ -199,9 +199,9 @@ namespace Fps
             }
         }
 
-        private void OnForcedRotaiton(RotationUpdate forcedRotaiton)
+        private void OnForcedRotation(RotationUpdate forcedRotation)
         {
-            var newPitch = Mathf.Clamp(forcedRotaiton.Pitch.ToFloat1k(), -cameraSettings.MaxPitch, -cameraSettings.MinPitch);
+            var newPitch = Mathf.Clamp(forcedRotation.Pitch.ToFloat1k(), -cameraSettings.MaxPitch, -cameraSettings.MinPitch);
             pitchTransform.localRotation = Quaternion.Euler(newPitch, 0, 0);
         }
         

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/FpsDriver.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/FpsDriver.cs
@@ -4,6 +4,7 @@ using Improbable.Gdk.GameObjectRepresentation;
 using Improbable.Gdk.Guns;
 using Improbable.Gdk.Health;
 using Improbable.Gdk.Movement;
+using Improbable.Gdk.StandardTypes;
 using UnityEngine;
 
 namespace Fps
@@ -20,6 +21,7 @@ namespace Fps
         }
 
         [Require] private ClientMovement.Requirable.Writer authority;
+        [Require] private ServerMovement.Requirable.Reader serverMovement;
         [Require] private GunStateComponent.Requirable.Writer gunState;
         [Require] private HealthComponent.Requirable.Reader health;
         [Require] private HealthComponent.Requirable.CommandRequestSender commandSender;
@@ -58,8 +60,8 @@ namespace Fps
         {
             Cursor.lockState = CursorLockMode.Locked;
             Cursor.visible = false;
+            serverMovement.OnForcedRotation += OnForcedRotaiton;
         }
-
 
         private void Update()
         {
@@ -197,6 +199,12 @@ namespace Fps
             }
         }
 
+        private void OnForcedRotaiton(RotationUpdate forcedRotaiton)
+        {
+            var newPitch = Mathf.Clamp(forcedRotaiton.Pitch.ToFloat1k(), -cameraSettings.MaxPitch, -cameraSettings.MinPitch);
+            pitchTransform.localRotation = Quaternion.Euler(newPitch, 0, 0);
+        }
+        
         // Cache the direction vectors to avoid having to normalize every time.
         private void CreateDirectionCache()
         {

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/Respawning/RespawnHandler.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/Respawning/RespawnHandler.cs
@@ -11,7 +11,6 @@ namespace Fps
     public class RespawnHandler : MonoBehaviour
     {
         [Require] private HealthComponent.Requirable.CommandRequestHandler respawnRequests;
-        [Require] private ClientRotation.Requirable.CommandRequestSender clientRotationRequest;
         [Require] private HealthComponent.Requirable.Writer health;
         [Require] private ServerMovement.Requirable.Writer serverMovement;
         [Require] private Position.Requirable.Writer spatialPosition;
@@ -64,7 +63,7 @@ namespace Fps
                 Pitch = spawnPitch.ToInt1k(),
                 TimeDelta = 0
             };
-            clientRotationRequest.SendForceRotationRequest(spatial.SpatialEntityId, forceRotationRequest);
+            serverMovement.SendForcedRotation(forceRotationRequest);
 
             // Trigger the respawn event.
             health.SendRespawn(new Empty());

--- a/workers/unity/Packages/com.improbable.gdk.movement/Behaviours/ClientMovementDriver.cs
+++ b/workers/unity/Packages/com.improbable.gdk.movement/Behaviours/ClientMovementDriver.cs
@@ -151,14 +151,14 @@ namespace Improbable.Gdk.Movement
             server.OnForcedRotation += OnForcedRotation;
         }
 
-        private void OnForcedRotation(RotationUpdate forcedRotaiton)
+        private void OnForcedRotation(RotationUpdate forcedRotation)
         {
             var rotationUpdate = new RotationUpdate
             {
-                Pitch = forcedRotaiton.Pitch,
-                Roll = forcedRotaiton.Roll,
-                Yaw = forcedRotaiton.Yaw,
-                TimeDelta = forcedRotaiton.TimeDelta
+                Pitch = forcedRotation.Pitch,
+                Roll = forcedRotation.Roll,
+                Yaw = forcedRotation.Yaw,
+                TimeDelta = forcedRotation.TimeDelta
             };
             var update = new ClientRotation.Update { Latest = new Option<RotationUpdate>(rotationUpdate) };
             rotation.Send(update);
@@ -167,9 +167,9 @@ namespace Improbable.Gdk.Movement
             pitchDirty = rollDirty = yawDirty = false;
             
             //Apply the forced rotation
-            var x = rotationConstraints.XAxisRotation ? forcedRotaiton.Pitch.ToFloat1k() : 0;
-            var y = rotationConstraints.YAxisRotation ? forcedRotaiton.Yaw.ToFloat1k() : 0;
-            var z = rotationConstraints.ZAxisRotation ? forcedRotaiton.Roll.ToFloat1k() : 0;
+            var x = rotationConstraints.XAxisRotation ? forcedRotation.Pitch.ToFloat1k() : 0;
+            var y = rotationConstraints.YAxisRotation ? forcedRotation.Yaw.ToFloat1k() : 0;
+            var z = rotationConstraints.ZAxisRotation ? forcedRotation.Roll.ToFloat1k() : 0;
             transform.rotation = Quaternion.Euler(x, y, z);
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.movement/Behaviours/ClientMovementDriver.cs
+++ b/workers/unity/Packages/com.improbable.gdk.movement/Behaviours/ClientMovementDriver.cs
@@ -148,6 +148,29 @@ namespace Improbable.Gdk.Movement
             spatialOSComponent = GetComponent<SpatialOSComponent>();
             origin = spatialOSComponent.Worker.Origin;
             server.LatestUpdated += OnServerUpdate;
+            server.OnForcedRotation += OnForcedRotation;
+        }
+
+        private void OnForcedRotation(RotationUpdate forcedRotaiton)
+        {
+            var rotationUpdate = new RotationUpdate
+            {
+                Pitch = forcedRotaiton.Pitch,
+                Roll = forcedRotaiton.Roll,
+                Yaw = forcedRotaiton.Yaw,
+                TimeDelta = forcedRotaiton.TimeDelta
+            };
+            var update = new ClientRotation.Update { Latest = new Option<RotationUpdate>(rotationUpdate) };
+            rotation.Send(update);
+
+            cumulativeRotationTimeDelta = 0;
+            pitchDirty = rollDirty = yawDirty = false;
+            
+            //Apply the forced rotation
+            var x = rotationConstraints.XAxisRotation ? forcedRotaiton.Pitch.ToFloat1k() : 0;
+            var y = rotationConstraints.YAxisRotation ? forcedRotaiton.Yaw.ToFloat1k() : 0;
+            var z = rotationConstraints.ZAxisRotation ? forcedRotaiton.Roll.ToFloat1k() : 0;
+            transform.rotation = Quaternion.Euler(x, y, z);
         }
 
         private void OnServerUpdate(ServerResponse update)

--- a/workers/unity/Packages/com.improbable.gdk.movement/Schema/movement.schema
+++ b/workers/unity/Packages/com.improbable.gdk.movement/Schema/movement.schema
@@ -34,12 +34,11 @@ component ServerMovement {
   id = 2021;
 
   ServerResponse latest = 1;
+  event RotationUpdate forced_rotation; 
 }
 
 component ClientRotation {
   id = 2022;
 
   RotationUpdate latest = 1;
-
-  command improbable.common.Empty force_rotation(RotationUpdate);
 }


### PR DESCRIPTION
Sami raised the issue that we are having performance issues with commands.
It is therefore desirable to remove command usage where possible.
It also appears the command wasn't even being used, and was throwing erros logs.
Therefore an event, with actual listen functionality, seems like a better approach.

To test:
Get shot while pointing in a specifically odd angle, respawn, check that you are now pointing at the angle that the respawn point wanted you to point.
Also check a fake-player heavy deployment, for lack of rotation command error lgos.