### PR TITLE
hotfix - Update build settings

### DIFF
--- a/workers/unity/ProjectSettings/EditorBuildSettings.asset
+++ b/workers/unity/ProjectSettings/EditorBuildSettings.asset
@@ -12,6 +12,6 @@ EditorBuildSettings:
     path: Assets/Fps/Scenes/FPS-GameLogic.unity
     guid: ec633e48fe0dc6c40acf1b3bc5bcc2da
   - enabled: 1
-    path: Assets/Fps/Scenes/FPS-FakeClientCoordinator.unity
+    path: Assets/Fps/Scenes/FPS-SimulatedPlayerCoordinator.unity
     guid: 2cc9e8eb323f45b4c8dad1fb41dc2831
   m_configObjects: {}


### PR DESCRIPTION
(Still uses FakeClient scene, despite it not existing)
- This is a generated change that I get when I attempt to build. I guess it was missing from the Simulated Players commit?