### PR TITLE
Prevent multiple ragdolls being spawned on death

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.ragdolls/Behaviours/RagdollSpawner.cs
+++ b/workers/unity/Packages/com.improbable.gdk.ragdolls/Behaviours/RagdollSpawner.cs
@@ -17,18 +17,18 @@ namespace Improbable.Gdk.Ragdoll
         public RagdollSpawned OnRagdollSpawned;
 
         private ObjectPool<PoolableRagdoll> pool;
-        private bool ragdollSpawned;
+        private bool hasRagdollSpawned;
 
         private void OnEnable()
         {
             health.OnHealthModified += OnHealthModified;
-            health.OnRespawn += empty => ragdollSpawned = false;
+            health.OnRespawn += (empty) => hasRagdollSpawned = false;
             pool = ObjectPooler.GetOrCreateObjectPool<PoolableRagdoll>(ragdollPrefab, 2);
         }
 
         private void OnHealthModified(HealthModifiedInfo info)
         {
-            if (info.Died && !ragdollSpawned)
+            if (info.Died && !hasRagdollSpawned)
             {
                 OnDeath(info.Modifier);
             }
@@ -36,7 +36,7 @@ namespace Improbable.Gdk.Ragdoll
 
         private void OnDeath(HealthModifier deathDetails)
         {
-            ragdollSpawned = true;
+            hasRagdollSpawned = true;
             var ragdoll = pool.Get();
             if (transformToMatch != null)
             {

--- a/workers/unity/Packages/com.improbable.gdk.ragdolls/Behaviours/RagdollSpawner.cs
+++ b/workers/unity/Packages/com.improbable.gdk.ragdolls/Behaviours/RagdollSpawner.cs
@@ -17,16 +17,18 @@ namespace Improbable.Gdk.Ragdoll
         public RagdollSpawned OnRagdollSpawned;
 
         private ObjectPool<PoolableRagdoll> pool;
+        private bool ragdollSpawned;
 
         private void OnEnable()
         {
             health.OnHealthModified += OnHealthModified;
+            health.OnRespawn += empty => ragdollSpawned = false;
             pool = ObjectPooler.GetOrCreateObjectPool<PoolableRagdoll>(ragdollPrefab, 2);
         }
-
+        
         private void OnHealthModified(HealthModifiedInfo info)
         {
-            if (info.Died)
+            if (info.Died && !ragdollSpawned)
             {
                 OnDeath(info.Modifier);
             }
@@ -34,6 +36,7 @@ namespace Improbable.Gdk.Ragdoll
 
         private void OnDeath(HealthModifier deathDetails)
         {
+            ragdollSpawned = true;
             var ragdoll = pool.Get();
             if (transformToMatch != null)
             {

--- a/workers/unity/Packages/com.improbable.gdk.ragdolls/Behaviours/RagdollSpawner.cs
+++ b/workers/unity/Packages/com.improbable.gdk.ragdolls/Behaviours/RagdollSpawner.cs
@@ -25,7 +25,7 @@ namespace Improbable.Gdk.Ragdoll
             health.OnRespawn += empty => ragdollSpawned = false;
             pool = ObjectPooler.GetOrCreateObjectPool<PoolableRagdoll>(ragdollPrefab, 2);
         }
-        
+
         private void OnHealthModified(HealthModifiedInfo info)
         {
             if (info.Died && !ragdollSpawned)


### PR DESCRIPTION
Currently multiple death events are being received per death.
Added a boolean flag to prevent multiple ragdolls spawning.

Ideally we would solve the root cause, but in the meantime, this is visually a very nasty bug, so a hotfix will improve the user experience in the short term.