### PR TITLE
MacOS Setup Script Fix

### DIFF
--- a/scripts/shell/setup.sh
+++ b/scripts/shell/setup.sh
@@ -19,8 +19,16 @@ echo ""
 echo "Welcome to the SpatialOS GDK for Unity FPS Starter Project setup script." 
 echo ""
 
-readonly RAW_DIR="$(CDPATH= cd -- "$(dirname -- $0)" && pwd)/../../../gdk-for-unity"
-readonly TARGET_DIRECTORY="$(realpath "${RAW_DIR}")"
+readonly RAW_DIR="$(dirname "${0}")/../../../gdk-for-unity"
+
+# Workaround for lack of realpath by default on MacOS
+#   1. Create the directory is it doesn't exist
+#   2. pushd there and record the directory through pwd
+#   3. This gives you a nice resolved path.
+mkdir -p "${RAW_DIR}"
+pushd "${RAW_DIR}" > /dev/null
+    readonly TARGET_DIRECTORY=$(pwd)
+popd > /dev/null
 
 echo_with_color "This script will create the following directory: ${TARGET_DIRECTORY}" "${LOG_WARNING}"
 echo_with_color "*** If such a directory already exists it will be deleted. ***" "${LOG_EMPHASIS}"

--- a/scripts/shell/setup.sh
+++ b/scripts/shell/setup.sh
@@ -19,7 +19,7 @@ echo ""
 echo "Welcome to the SpatialOS GDK for Unity FPS Starter Project setup script." 
 echo ""
 
-readonly RAW_DIR="$(dirname "${0}")/../../../gdk-for-unity"
+readonly RAW_DIR="$(CDPATH= cd -- "$(dirname -- $0)" && pwd)/../../../gdk-for-unity"
 readonly TARGET_DIRECTORY="$(realpath "${RAW_DIR}")"
 
 echo_with_color "This script will create the following directory: ${TARGET_DIRECTORY}" "${LOG_WARNING}"


### PR DESCRIPTION
#### Description
If a user has MacOS and has not installed `coreutils` through `brew` they will not have `realpath`. This PR introduces a workaround for this - but at the cost of it no longer follows symlinks. This is probably okay - and the user has to provide confirmation to the path given to them.
#### Tests
Tested on MacOS and Git Bash
#### Documentation
N/A
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jared-improbable @jessicafalk 