### PR TITLE
Bug fix - aiming up

### DIFF
--- a/workers/unity/Assets/Fps/Scripts/SimulatedPlayer/SimulatedPlayerDriver.cs
+++ b/workers/unity/Assets/Fps/Scripts/SimulatedPlayer/SimulatedPlayerDriver.cs
@@ -187,7 +187,6 @@ public class SimulatedPlayerDriver : MonoBehaviour
                 movementDriver.CurrentRoll);
             if (shooting.IsShooting(true) && Mathf.Abs(Quaternion.Angle(targetRotation, aimRotation)) < 5)
             {
-                Debug.Log(aimRotation * Vector3.forward);
                 shooting.FireShot(200f, new Ray(gunOrigin, aimRotation * Vector3.forward));
                 shooting.InitiateCooldown(0.2f);
                 lastShotTime = Time.time;

--- a/workers/unity/Assets/Fps/Scripts/SimulatedPlayer/SimulatedPlayerDriver.cs
+++ b/workers/unity/Assets/Fps/Scripts/SimulatedPlayer/SimulatedPlayerDriver.cs
@@ -183,9 +183,12 @@ public class SimulatedPlayerDriver : MonoBehaviour
             GetComponent<ClientMovementDriver>().ApplyMovement(
                 strafeRight ? transform.right : -transform.right, rotationAmount, MovementSpeed.Run, false);
 
-            if (shooting.IsShooting(true) && Mathf.Abs(Quaternion.Angle(targetRotation, transform.rotation)) < 5)
+            var aimRotation = Quaternion.Euler(movementDriver.CurrentPitch, movementDriver.CurrentYaw,
+                movementDriver.CurrentRoll);
+            if (shooting.IsShooting(true) && Mathf.Abs(Quaternion.Angle(targetRotation, aimRotation)) < 5)
             {
-                shooting.FireShot(200f, new Ray(gunOrigin, transform.forward));
+                Debug.Log(aimRotation * Vector3.forward);
+                shooting.FireShot(200f, new Ray(gunOrigin, aimRotation * Vector3.forward));
                 shooting.InitiateCooldown(0.2f);
                 lastShotTime = Time.time;
             }


### PR DESCRIPTION
Note: The gun bullet snapping is still quite wonky - The fact that the fudge factor is recalculated every update probably doesn't help. May be worth experimenting with the rotation speeds and the assorted thresholds to see if it helps (Build out clients seem to bullet snap fine - may be that the gun's pitch changes too suddenly? Possibly after shooting it snaps to something?)
(Used the transform rotation of the object (which is constrained to 0 pitch), rather than the actual pitch of the gun)