### PR TITLE
[Fix] players stuck after respawn

### DIFF
--- a/workers/unity/Assets/Fps/Scripts/GameLogic/VisibilityAndCollision.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/VisibilityAndCollision.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Improbable.Common;
 using Improbable.Gdk.GameObjectRepresentation;
 using Improbable.Gdk.Health;
 using UnityEngine;
@@ -10,7 +9,7 @@ namespace Fps
     {
         [Require] private HealthComponent.Requirable.Reader health;
 
-        private bool isDead = false;
+        private bool isVisible = true;
 
         private CharacterController characterController;
         [SerializeField] private List<Renderer> renderersToIgnore = new List<Renderer>();
@@ -22,60 +21,36 @@ namespace Fps
 
         private void OnEnable()
         {
-            health.OnRespawn += OnRespawn;
-            health.OnHealthModified += OnHealthModified;
-            ApplyState();
-            SetIsDeadState(health.Data.Health <= 0);
+            health.HealthUpdated += HealthUpdated;
+            SetIsVisible(health.Data.Health > 0);
         }
 
-        private void Start()
+        private void SetIsVisible(bool visible)
         {
-            ApplyState();
-        }
-
-        private void OnRespawn(Empty empty)
-        {
-            SetIsDeadState(false);
-        }
-
-        private void OnHealthModified(HealthModifiedInfo info)
-        {
-            if (info.Died)
+            if (visible == isVisible)
             {
-                SetIsDeadState(true);
+                return;
             }
-        }
 
-        private void SetIsDeadState(bool newDeadState)
-        {
-            if (isDead != newDeadState)
-            {
-                isDead = newDeadState;
-                ApplyState();
-            }
-        }
+            isVisible = visible;
 
-        private void ApplyState()
-        {
-            SetRenderersEnabled(transform, !isDead);
-        }
-
-        private void SetRenderersEnabled(Transform root, bool enabled)
-        {
-            // Enable/Disable the character controller (to turn on/off collision)
             if (characterController)
             {
-                characterController.enabled = enabled;
+                characterController.enabled = visible;
             }
 
-            // Enable/Disable the renderers to turn on/off the model's visibility.
-            foreach (var renderer in GetComponentsInChildren<Renderer>())
+            foreach (var r in GetComponentsInChildren<Renderer>())
             {
-                if (!renderersToIgnore.Contains(renderer))
+                if (!renderersToIgnore.Contains(r))
                 {
-                    renderer.enabled = enabled;
+                    r.enabled = visible;
                 }
             }
+        }
+
+        private void HealthUpdated(float newHealth)
+        {
+            SetIsVisible(newHealth > 0);
         }
     }
 }

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/VisibilityAndCollision.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/VisibilityAndCollision.cs
@@ -22,11 +22,23 @@ namespace Fps
         private void OnEnable()
         {
             health.HealthUpdated += HealthUpdated;
-            SetIsVisible(health.Data.Health > 0);
+            UpdateVisibility();
         }
 
-        private void SetIsVisible(bool visible)
+        private void HealthUpdated(float newHealth)
         {
+            UpdateVisibility();
+        }
+
+        private void UpdateVisibility()
+        {
+            if (health == null)
+            {
+                return;
+            }
+
+            var visible = (health.Data.Health > 0);
+
             if (visible == isVisible)
             {
                 return;
@@ -39,18 +51,13 @@ namespace Fps
                 characterController.enabled = visible;
             }
 
-            foreach (var r in GetComponentsInChildren<Renderer>())
+            foreach (var childRenderer in GetComponentsInChildren<Renderer>())
             {
-                if (!renderersToIgnore.Contains(r))
+                if (!renderersToIgnore.Contains(childRenderer))
                 {
-                    r.enabled = visible;
+                    childRenderer.enabled = visible;
                 }
             }
-        }
-
-        private void HealthUpdated(float newHealth)
-        {
-            SetIsVisible(newHealth > 0);
         }
     }
 }


### PR DESCRIPTION
#### Description
1. Delay updating spatial position when respawning player to the next frame, this ensures that the other component updates all get updated before the potential worker transition.
1. Refactor VisibiltyAndCollision to listen to health updates and not respawn/healthmodified events since these may not arrive after worker transition.
#### Tests
Tested in local deployment, and in cloud deployment. Did not get stuck, or see simulated players floating in the air