### PR TITLE
Bugfix/AI navigation

### DIFF
--- a/workers/unity/Assets/Fps/Scripts/SimulatedPlayer/SimulatedPlayerDriver.cs
+++ b/workers/unity/Assets/Fps/Scripts/SimulatedPlayer/SimulatedPlayerDriver.cs
@@ -84,6 +84,7 @@ public class SimulatedPlayerDriver : MonoBehaviour
         if (state == PlayerState.Dead)
         {
             anchorPoint = transform.position;
+            agent.Warp(transform.position);
             SetPlayerState(PlayerState.LookingForTarget);
         }
     }
@@ -140,13 +141,10 @@ public class SimulatedPlayerDriver : MonoBehaviour
     {
         if (!agent.isOnNavMesh)
         {
-            // If agent has fallen off the nav mesh, move forward and attempt to get back on the navmesh.
-            var velocity = transform.forward;
-            var rotation = Quaternion.LookRotation(velocity, Vector3.up);
-            var speed = sprintNext ? MovementSpeed.Sprint : MovementSpeed.Run;
-            movementDriver.ApplyMovement(velocity, rotation, speed, jumpNext);
-            jumpNext = false;
-            agent.Warp(transform.position);
+            if (NavMesh.SamplePosition(transform.position, out var hit, 0.5f, NavMesh.AllAreas))
+            {
+                agent.Warp(hit.position);
+            }
         }
         else if (agent.remainingDistance < MinRemainingDistance || agent.pathStatus == NavMeshPathStatus.PathInvalid ||
             !agent.hasPath)
@@ -161,7 +159,7 @@ public class SimulatedPlayerDriver : MonoBehaviour
             {
                 var rotation = Quaternion.LookRotation(velocity, Vector3.up);
                 var speed = sprintNext ? MovementSpeed.Sprint : MovementSpeed.Run;
-                movementDriver.ApplyMovement(velocity, rotation, speed, jumpNext);
+                MoveTowards(transform.position + velocity, speed, rotation, jumpNext);
                 jumpNext = false;
             }
         }
@@ -180,8 +178,9 @@ public class SimulatedPlayerDriver : MonoBehaviour
             var targetRotation = Quaternion.LookRotation(targetCenter - gunOrigin);
             var rotationAmount = Quaternion.RotateTowards(transform.rotation, targetRotation, 10f);
 
-            GetComponent<ClientMovementDriver>().ApplyMovement(
-                strafeRight ? transform.right : -transform.right, rotationAmount, MovementSpeed.Run, false);
+            var destination = transform.position + (strafeRight ? transform.right : -transform.right);
+
+            MoveTowards(destination, MovementSpeed.Run, rotationAmount, false);
 
             if (shooting.IsShooting(true) && Mathf.Abs(Quaternion.Angle(targetRotation, transform.rotation)) < 5)
             {
@@ -201,6 +200,17 @@ public class SimulatedPlayerDriver : MonoBehaviour
             target = null;
             SetPlayerState(PlayerState.LookingForTarget);
         }
+    }
+
+    private void MoveTowards(Vector3 destination, MovementSpeed speed, Quaternion rotation, bool jump = false)
+    {
+        var agentPosition = agent.nextPosition;
+        var direction = (destination - agentPosition).normalized;
+        var desiredVelocity = direction * movementDriver.GetSpeed(speed);
+        agent.nextPosition += desiredVelocity * Time.deltaTime;
+        var actualDirection = (agent.nextPosition - agentPosition).normalized;
+
+        movementDriver.ApplyMovement(actualDirection, rotation, speed, jump);
     }
 
     private bool TargetIsValid()
@@ -316,7 +326,9 @@ public class SimulatedPlayerDriver : MonoBehaviour
                 similarPositionsCount++;
                 if (similarPositionsCount >= maxSimilarPositions)
                 {
-                    Debug.LogWarningFormat("{0} got stuck at {1}, respawning", name, transform.position);
+                    Debug.LogWarningFormat("{0} got stuck at {1}: agent at {2}, respawning",
+                        name, transform.position, agent.nextPosition);
+
                     SetPlayerState(PlayerState.Dead);
                 }
             }

--- a/workers/unity/Assets/Fps/Scripts/SimulatedPlayer/SimulatedPlayerDriver.cs
+++ b/workers/unity/Assets/Fps/Scripts/SimulatedPlayer/SimulatedPlayerDriver.cs
@@ -207,7 +207,11 @@ public class SimulatedPlayerDriver : MonoBehaviour
         var agentPosition = agent.nextPosition;
         var direction = (destination - agentPosition).normalized;
         var desiredVelocity = direction * movementDriver.GetSpeed(speed);
+
+        // Setting nextPosition will move the agent towards destination, but is constrained by the navmesh
         agent.nextPosition += desiredVelocity * Time.deltaTime;
+
+        // Getting nextPosition here will return the constrained position of the agent
         var actualDirection = (agent.nextPosition - agentPosition).normalized;
 
         movementDriver.ApplyMovement(actualDirection, rotation, speed, jump);

--- a/workers/unity/Packages/com.improbable.gdk.movement/Behaviours/ClientMovementDriver.cs
+++ b/workers/unity/Packages/com.improbable.gdk.movement/Behaviours/ClientMovementDriver.cs
@@ -165,7 +165,7 @@ namespace Improbable.Gdk.Movement
 
             cumulativeRotationTimeDelta = 0;
             pitchDirty = rollDirty = yawDirty = false;
-            
+
             //Apply the forced rotation
             var x = rotationConstraints.XAxisRotation ? forcedRotation.Pitch.ToFloat1k() : 0;
             var y = rotationConstraints.YAxisRotation ? forcedRotation.Yaw.ToFloat1k() : 0;
@@ -280,7 +280,7 @@ namespace Improbable.Gdk.Movement
             CurrentRoll = rotation.eulerAngles.z;
         }
 
-        private float GetSpeed(MovementSpeed requestedSpeed)
+        public float GetSpeed(MovementSpeed requestedSpeed)
         {
             switch (requestedSpeed)
             {


### PR DESCRIPTION
#### Description
1. Use NavAgent.nextPosition in new method MoveTowards to adjust desired movement so agents don't walk off the navmesh as often.
1. Use MoveTowards to strafe when shooting, instead of ignore the navmesh completely.
1. Use NavMesh.SamplePosition + NavAgent.Warp to attempt to recover an agent that is not on the navmesh.
1. Report agent.nextPosition in addition to simulated player transform if stationary for a significant amount of time.

#### Tests
Tested behaviour of 200 simulated players in a cloud deployment and observed far fewer 'stuck' players, even after over an hour.