### PR TITLE
adding packages required for 2018.2.13 support

### DIFF
--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -21,10 +21,14 @@
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.imgui": "1.0.0",
+    "com.unity.modules.jsonserialize": "1.0.0",
     "com.unity.modules.particlesystem": "1.0.0",
     "com.unity.modules.physics": "1.0.0",
     "com.unity.modules.ui": "1.0.0",
+    "com.unity.modules.unityanalytics": "1.0.0",
+    "com.unity.modules.unitywebrequest": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
+    "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
   "registry": "https://staging-packages.unity.com"


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Unity changed the dependencies of their in-built packages. That was causing all the errors when using the latest 2018.2 with the fps starter project.

#### Tests
Tested locally with 2018.2.13 and 2018.2.8. No errors are thrown anymore.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.