### PR TITLE
UTY-1363: Rolled back double ragdoll masking code

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.ragdolls/Behaviours/RagdollSpawner.cs
+++ b/workers/unity/Packages/com.improbable.gdk.ragdolls/Behaviours/RagdollSpawner.cs
@@ -17,18 +17,16 @@ namespace Improbable.Gdk.Ragdoll
         public RagdollSpawned OnRagdollSpawned;
 
         private ObjectPool<PoolableRagdoll> pool;
-        private bool hasRagdollSpawned;
 
         private void OnEnable()
         {
             health.OnHealthModified += OnHealthModified;
-            health.OnRespawn += (empty) => hasRagdollSpawned = false;
             pool = ObjectPooler.GetOrCreateObjectPool<PoolableRagdoll>(ragdollPrefab, 2);
         }
 
         private void OnHealthModified(HealthModifiedInfo info)
         {
-            if (info.Died && !hasRagdollSpawned)
+            if (info.Died)
             {
                 OnDeath(info.Modifier);
             }
@@ -36,7 +34,6 @@ namespace Improbable.Gdk.Ragdoll
 
         private void OnDeath(HealthModifier deathDetails)
         {
-            hasRagdollSpawned = true;
             var ragdoll = pool.Get();
             if (transformToMatch != null)
             {


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Roll back Peter's masking fix now that the root cause has been resolved (https://github.com/spatialos/gdk-for-unity/pull/564)
#### Tests
Manual. Deployed and wasn't able to reproduce the bug anymore
#### Documentation
None
#### Primary reviewers
@peterimprobable @mattyoung-improbable 