### PR TITLE
Simulated players can now shoot targets on different planes to them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Simulated Players can now rotate about the X axis, enabling them to shoot targets above or below the plane they are on.
+
 ### Removed
 
 - Removed GameObjects containing `ObjectPooler` from all scenes, `ObjectPooler` instance is now created at runtime.

--- a/workers/unity/Assets/Fps/Resources/Prefabs/SimulatedPlayer/SimulatedPlayer.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/SimulatedPlayer/SimulatedPlayer.prefab
@@ -191,7 +191,7 @@ MonoBehaviour:
     AirControlModifier: 0.25
     InAirDamping: 0.5
   rotationConstraints:
-    XAxisRotation: 0
+    XAxisRotation: 1
     YAxisRotation: 1
     ZAxisRotation: 0
 --- !u!114 &114779873026297234


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](https://github.com/spatialos/gdk-for-unity#give-us-feedback).

-------

#### Description
* enable rotation about the x-axis so that the `MoveTowards` method actually enables simulated players to look at targets on different heights to them

#### Tests
* looked at transforms in-editor when running a cloud deployment
* ran a built out client, took the higher ground, still got killed

#### Documentation
n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.