### PR TITLE
Fixing launch configuration for OSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Simulated Players can now rotate about the X axis, enabling them to shoot targets above or below the plane they are on.
+- Fixed a bug where you could start each built-out worker only once on OSX.
 
 ### Removed
 

--- a/workers/unity/spatialos.SimulatedPlayer.worker.json
+++ b/workers/unity/spatialos.SimulatedPlayer.worker.json
@@ -36,6 +36,7 @@
       "macos": {
         "command": "open",
         "arguments": [
+          "-n",
           "./build/worker/SimulatedPlayer@Mac/SimulatedPlayer@Mac.app",
           "--args",
           "+assemblyName",

--- a/workers/unity/spatialos.SimulatedPlayerCoordinator.worker.json
+++ b/workers/unity/spatialos.SimulatedPlayerCoordinator.worker.json
@@ -52,6 +52,7 @@
       "macos": {
         "command": "open",
         "arguments": [
+          "-n",
           "./build/worker/SimulatedPlayerCoordinator@Mac/SimulatedPlayerCoordinator@Mac.app",
           "--args",
           "+assemblyName",
@@ -95,10 +96,8 @@
     },
     "macos": {
       "artifact_name": "SimulatedPlayerCoordinator@Mac.zip",
-      "command": "open",
+      "command": "SimulatedPlayerCoordinator@Mac.app/Contents/MacOS/SimulatedPlayerCoordinator@Mac",
       "arguments": [
-        "SimulatedPlayerCoordinator@Mac.app",
-        "--args",
         "+workerType",
         "SimulatedPlayerCoordinator",
         "+workerId",

--- a/workers/unity/spatialos.UnityClient.worker.json
+++ b/workers/unity/spatialos.UnityClient.worker.json
@@ -50,6 +50,7 @@
       "macos": {
         "command": "open",
         "arguments": [
+          "-n",
           "./build/worker/UnityClient@Mac/UnityClient@Mac.app",
           "--args",
           "+assemblyName",

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -52,6 +52,7 @@
       "macos": {
         "command": "open",
         "arguments": [
+          "-n",
           "./build/worker/UnityGameLogic@Mac/UnityGameLogic@Mac.app",
           "--args",
           "+assemblyName",
@@ -95,10 +96,8 @@
     },
     "macos": {
       "artifact_name": "UnityGameLogic@Mac.zip",
-      "command": "open",
+      "command": "UnityGameLogic@Mac.app/Contents/MacOS/UnityGameLogic@Mac",
       "arguments": [
-        "UnityGameLogic@Mac.app",
-        "--args",
         "+workerType",
         "UnityGameLogic",
         "+workerId",


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](https://github.com/spatialos/gdk-for-unity#give-us-feedback).

-------

#### Description
We had the wrong OSX launch configuration and therefore it was not possible to start the same worker type multiple times.

#### Tests
Ran it locally with and tested all the external workers locally as well.


#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.