### PR TITLE
Split single 'look sensitivity' into seperate yaw/pitch sensitivities…

### DIFF
--- a/workers/unity/Assets/Fps/Resources/Prefabs/AndroidClient/Authoritative/Player.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/AndroidClient/Authoritative/Player.prefab
@@ -2831,9 +2831,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MovementScalar: 0.01
-  LookScalar: 0.14
+  YawMultiplier: 0.15
+  PitchMultiplier: 0.12
+  FiringLookMultiplier: 0.75
   SprintMaxAngle: 30
-  SprintDistanceThreshold: 100
 --- !u!114 &114711516255448412
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/PlayerControls/MobileControls.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/PlayerControls/MobileControls.cs
@@ -6,14 +6,20 @@ public class MobileControls : MonoBehaviour, IControlProvider
     private IMobileUI mobileUI;
 
     public float MovementScalar = 0.01f;
-    public float LookScalar = 0.33f;
+    public float YawMultiplier = 0.15f;
+    public float PitchMultiplier = 0.12f;
+    public float FiringLookMultiplier = .8f;
     public float SprintMaxAngle = 30f;
     public float SprintDistanceThreshold => mobileUI.MaxStickDistance;
 
     // TODO Currently YawDelta/PitchDelta is untested on different devices. Probably needs some more love to resolve
     // DPI/physical screen size differences.
-    public float YawDelta => mobileUI.LookDelta.x * LookScalar;
-    public float PitchDelta => mobileUI.LookDelta.y * LookScalar;
+    public float YawDelta =>
+        mobileUI.LookDelta.x * YawMultiplier * (mobileUI.ShootHeld ? FiringLookMultiplier : 1f);
+
+    public float PitchDelta =>
+        mobileUI.LookDelta.y * PitchMultiplier * (mobileUI.ShootHeld ? FiringLookMultiplier : 1f);
+
     public bool IsAiming => mobileUI.IsAiming;
 
     public bool JumpPressed => mobileUI.JumpPressed;


### PR DESCRIPTION
Basic update to aiming. Split single looking-about sensitivity into separate pitch/yaw sensitivities, and made pitching less sensitive on player prefab.

Also added a firing sensitivity multiplier to make aiming easier when shooting.