### PR TITLE
Feature/mobile mapbuilder update

### DIFF
--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Ground/Edge.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Ground/Edge.prefab
@@ -83,7 +83,7 @@ MeshFilter:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1096249949341726}
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!64 &64981074544283414
 MeshCollider:
   m_ObjectHideFlags: 1
@@ -97,4 +97,4 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 14
   m_SkinWidth: 0.01
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}

--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Surround/Corner.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Surround/Corner.prefab
@@ -1,0 +1,481 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1608117843586412}
+  m_IsPrefabAsset: 1
+--- !u!1 &1036617106745020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4480638599536360}
+  - component: {fileID: 33445546354949486}
+  - component: {fileID: 23416418166766922}
+  - component: {fileID: 64682133348742432}
+  m_Layer: 0
+  m_Name: Edge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!1 &1290318892992282
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4827167669406710}
+  - component: {fileID: 33343427053656414}
+  - component: {fileID: 23050492192103342}
+  - component: {fileID: 64751964885761710}
+  m_Layer: 0
+  m_Name: Edge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!1 &1572923996142514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4100072802957014}
+  - component: {fileID: 33013274038650070}
+  - component: {fileID: 23356058494536124}
+  - component: {fileID: 64482058376715630}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!1 &1608117843586412
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4903314902179232}
+  m_Layer: 0
+  m_Name: Corner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1814768520609000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4117639564479278}
+  - component: {fileID: 33361144356598774}
+  - component: {fileID: 23322707067556500}
+  - component: {fileID: 64721240366635550}
+  m_Layer: 0
+  m_Name: Edge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!1 &1917500287002772
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4935778459092190}
+  - component: {fileID: 33638228890067130}
+  - component: {fileID: 23123268169414024}
+  - component: {fileID: 64342511406177574}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &4100072802957014
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1572923996142514}
+  m_LocalRotation: {x: -0, y: 0.00000047683716, z: -0, w: -1}
+  m_LocalPosition: {x: -1, y: 2, z: 2}
+  m_LocalScale: {x: 2, y: 4, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4903314902179232}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 180, y: 180, z: -180}
+--- !u!4 &4117639564479278
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1814768520609000}
+  m_LocalRotation: {x: -0.000000030908623, y: 0.7071068, z: -0.7071068, w: -0.000000030908623}
+  m_LocalPosition: {x: -1, y: 0, z: 1}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4903314902179232}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4480638599536360
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1036617106745020}
+  m_LocalRotation: {x: -0.000000030908623, y: 0.7071068, z: -0.7071068, w: -0.000000030908623}
+  m_LocalPosition: {x: -4, y: 4, z: 3}
+  m_LocalScale: {x: 4, y: 6, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4903314902179232}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4827167669406710
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1290318892992282}
+  m_LocalRotation: {x: -0.000000030908623, y: 0.7071068, z: -0.7071068, w: -0.000000030908623}
+  m_LocalPosition: {x: -1, y: 4, z: 4}
+  m_LocalScale: {x: 2, y: 4, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4903314902179232}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4903314902179232
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1608117843586412}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4827167669406710}
+  - {fileID: 4117639564479278}
+  - {fileID: 4480638599536360}
+  - {fileID: 4935778459092190}
+  - {fileID: 4100072802957014}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4935778459092190
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1917500287002772}
+  m_LocalRotation: {x: -0, y: 0.70710677, z: 0.000000014348011, w: -0.7071068}
+  m_LocalPosition: {x: -2, y: 2, z: 1}
+  m_LocalScale: {x: 2, y: 4, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4903314902179232}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 180, y: -90, z: -90}
+--- !u!23 &23050492192103342
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1290318892992282}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 91fe024fab287f243beedec61640e4f1, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!23 &23123268169414024
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1917500287002772}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 183539042e27d554c976de8c750607bf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!23 &23322707067556500
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1814768520609000}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 91fe024fab287f243beedec61640e4f1, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!23 &23356058494536124
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1572923996142514}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 183539042e27d554c976de8c750607bf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!23 &23416418166766922
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1036617106745020}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 91fe024fab287f243beedec61640e4f1, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33013274038650070
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1572923996142514}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &33343427053656414
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1290318892992282}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &33361144356598774
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1814768520609000}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &33445546354949486
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1036617106745020}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &33638228890067130
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1917500287002772}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!64 &64342511406177574
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1917500287002772}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!64 &64482058376715630
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1572923996142514}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!64 &64682133348742432
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1036617106745020}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!64 &64721240366635550
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1814768520609000}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!64 &64751964885761710
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1290318892992282}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}

--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Surround/Corner.prefab.meta
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Surround/Corner.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5972c5f5f295d0459428c236647d7ba
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Fps/Scripts/Config/MapBuilder.cs
+++ b/workers/unity/Assets/Fps/Scripts/Config/MapBuilder.cs
@@ -132,7 +132,11 @@ public class MapBuilder : MonoBehaviour
 
         if (centreTiles.Any(t => t == null))
         {
-            Debug.LogError("Failed to load CentreTile# resources");
+            Debug.LogError("Failed to load CentreTile resource (Expecting all the following paths to exist: " +
+                $"\t{CentreTile0}" +
+                $"\t{CentreTile1}" +
+                $"\t{CentreTile2}" +
+                $"\t{CentreTile3}");
             return false;
         }
 

--- a/workers/unity/Assets/Fps/Scripts/Config/MapBuilder.cs
+++ b/workers/unity/Assets/Fps/Scripts/Config/MapBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Fps;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
@@ -12,32 +13,33 @@ public class MapBuilder : MonoBehaviour
     public float EmptyTileChance = 0.2f;
 
     private const int TileSeparation = 36;
-    private const float GroundHeight = 0f;
-    private const float HeightOffset = 0.5f;
 
     private int groundWidth;
-    private const int WallHeight = 4;
+    private const int BlockSize = 4;
 
     private GameObject[] centreTiles;
     private GameObject[] levelTiles;
     private GameObject groundTile;
     private GameObject groundEdge;
     private GameObject surroundWall;
+    private GameObject cornerPiece;
 
     private Transform tileParentTransform;
     private Transform groundParentTransform;
     private Transform surroundParentTransform;
     private Transform cubeParentTransform;
+    private Transform spawnPointSystemTransform;
 
     private const string TileParentName = "TileParent";
     private const string GroundParentName = "GroundParent";
     private const string SurroundParentName = "SurroundParent";
-    private const string CubeParentName = "CubeParent";
+    private const string SpawnPointSystemName = "SpawnPointSystem";
 
     private const string LevelTilePath = "Prefabs/Level/Tiles";
     private const string GroundTilePath = "Prefabs/Level/Ground/Ground4x4";
     private const string GroundEdgePath = "Prefabs/Level/Ground/Edge";
     private const string SurroundPath = "Prefabs/Level/Surround/Wall";
+    private const string CornerPath = "Prefabs/Level/Surround/Corner";
 
     // Central tiles are hardcoded.
     private const string CentreTile0 = "Prefabs/Level/Tiles/Centre0";
@@ -45,20 +47,82 @@ public class MapBuilder : MonoBehaviour
     private const string CentreTile2 = "Prefabs/Level/Tiles/Centre2";
     private const string CentreTile3 = "Prefabs/Level/Tiles/Centre3";
 
+    private int groundLayers => (Layers - 1) / 4 + 1;
+
 #if UNITY_EDITOR
-    public void Build()
+    public void CleanAndBuild()
     {
+        if (TryLoadResources() == false)
+        {
+            Debug.LogError("Generation aborted due to error");
+            return;
+        }
+
+        Clean();
+
+        InitializeGroupsAndComponents();
         Random.InitState(Seed.GetHashCode());
+
+        var originalPosition = transform.position;
+        var originalRotation = transform.rotation;
+        transform.position = Vector3.zero;
+        transform.rotation = Quaternion.identity;
         PlaceTiles();
         PlaceGround();
-        PlaceSurround();
+        FillSurround();
         MakeLevelObjectStatic();
-        Debug.Log($"Finished building world of size: {groundWidth} x {groundWidth}");
+
+        transform.position = originalPosition;
+        transform.rotation = originalRotation;
+
+        var worldSize = groundLayers * TileSeparation * 4 * 2 + 4;
+        Debug.Log($"Finished building world of size: {worldSize} x {worldSize}");
     }
 
-    private void PlaceTiles()
+    private void InitializeGroupsAndComponents()
     {
-        centreTiles = new GameObject[]
+        if (!gameObject.GetComponent<TileSettings>())
+        {
+            gameObject.AddComponent<TileSettings>();
+        }
+
+        if (!GetComponentInChildren<SpawnPoints>())
+        {
+            spawnPointSystemTransform = MakeGroup(SpawnPointSystemName);
+            spawnPointSystemTransform.gameObject.AddComponent<SpawnPoints>();
+        }
+
+        groundParentTransform = MakeGroup(GroundParentName);
+
+        surroundParentTransform = MakeGroup(SurroundParentName);
+
+        tileParentTransform = MakeGroup(TileParentName);
+        tileParentTransform.gameObject.AddComponent<TileCollapser>();
+    }
+
+    private bool TryLoadResources()
+    {
+        if (!TryLoadResource(GroundTilePath, out groundTile))
+        {
+            return false;
+        }
+
+        if (!TryLoadResource(GroundEdgePath, out groundEdge))
+        {
+            return false;
+        }
+
+        if (!TryLoadResource(SurroundPath, out surroundWall))
+        {
+            return false;
+        }
+
+        if (!TryLoadResource(CornerPath, out cornerPiece))
+        {
+            return false;
+        }
+
+        centreTiles = new[]
         {
             Resources.Load<GameObject>(CentreTile0),
             Resources.Load<GameObject>(CentreTile1),
@@ -68,21 +132,115 @@ public class MapBuilder : MonoBehaviour
 
         if (centreTiles.Any(t => t == null))
         {
-            Debug.LogError("Central tile prefabs not loaded.");
-            return;
+            Debug.LogError("Failed to load CentreTile# resources");
+            return false;
         }
 
         levelTiles = Resources.LoadAll<GameObject>(LevelTilePath);
 
         if (levelTiles.Length <= 0)
         {
-            Debug.LogError("Tile prefabs not loaded.");
-            return;
+            Debug.LogError($"Failed to load resource at {LevelTilePath}");
+            return false;
         }
 
-        tileParentTransform = new GameObject(TileParentName).transform;
-        tileParentTransform.parent = gameObject.transform;
+        return true;
+    }
 
+    private bool TryLoadResource(string resourcePath, out GameObject resource)
+    {
+        resource = Resources.Load<GameObject>(resourcePath);
+        if (resource != null)
+        {
+            return true;
+        }
+
+        Debug.LogError($"Failed to load resource at {resourcePath}");
+        return false;
+    }
+
+    private Transform MakeGroup(string groupName)
+    {
+        var group = new GameObject(groupName).transform;
+        group.parent = transform;
+        group.localPosition = Vector3.zero;
+        group.localRotation = Quaternion.identity;
+        group.localScale = Vector3.one;
+        return group;
+    }
+
+    private void FillSurround()
+    {
+        for (var i = -groundLayers; i < groundLayers; i++)
+        {
+            var offset = TileSeparation * 4 * i + TileSeparation * 2;
+            MakeEdge(offset, 0);
+            MakeEdge(offset, 90);
+            MakeEdge(offset, 180);
+            MakeEdge(offset, 270);
+        }
+
+        for (var i = 0; i < 360; i += 90)
+        {
+            MakeCorner(i);
+        }
+    }
+
+    private void MakeEdge(float offset, int angle)
+    {
+        var rotation = Quaternion.Euler(0, angle, 0);
+
+        var floor = Instantiate(groundEdge,
+            rotation * new Vector3(offset, 0, groundLayers * TileSeparation * 4 + BlockSize * 0.25f),
+            rotation * Quaternion.Euler(90, 0, 0),
+            groundParentTransform);
+        floor.transform.localScale = new Vector3(144, 2, 1);
+
+        var wall = Instantiate(surroundWall,
+            rotation * new Vector3(offset, BlockSize * .5f, groundLayers * TileSeparation * 4 + BlockSize * .5f),
+            rotation,
+            surroundParentTransform);
+        wall.transform.localScale = new Vector3(144, 4, 1);
+
+        var wallFloor = Instantiate(groundEdge,
+            rotation * new Vector3(offset, BlockSize, groundLayers * TileSeparation * 4 + BlockSize),
+            rotation * Quaternion.Euler(90, 0, 0),
+            surroundParentTransform);
+        wallFloor.transform.localScale = new Vector3(144, 4, 1);
+
+        // Collision
+        var collisionHeight = 16;
+        var collision = Instantiate(surroundWall,
+            rotation * new Vector3(offset, BlockSize + collisionHeight * .5f,
+                groundLayers * TileSeparation * 4 + BlockSize * .5f),
+            rotation,
+            surroundParentTransform);
+        collision.transform.localScale = new Vector3(144 + 4, collisionHeight, 1); // Collisions overlap to fill corners
+        collision.gameObject.name = "Collision";
+
+        if (Application.isPlaying)
+        {
+            Destroy(collision.GetComponent<MeshRenderer>());
+            Destroy(collision.GetComponent<MeshFilter>());
+        }
+        else
+        {
+            DestroyImmediate(collision.GetComponent<MeshRenderer>());
+            DestroyImmediate(collision.GetComponent<MeshFilter>());
+        }
+    }
+
+    private void MakeCorner(int angle)
+    {
+        var rotation = Quaternion.Euler(0, angle, 0);
+        Instantiate(cornerPiece,
+            rotation * new Vector3(-groundLayers * TileSeparation * 4, 0, groundLayers * TileSeparation * 4),
+            rotation,
+            surroundParentTransform);
+    }
+
+    private void PlaceTiles()
+    {
         var tileCoord = new Vector2Int();
         var diff = new Vector2Int(0, -1);
 
@@ -91,7 +249,8 @@ public class MapBuilder : MonoBehaviour
         for (var i = 0; i < tileCount; i++)
         {
             // -layers < x <= layers AND -layers < y <= layers
-            if (-Layers < tileCoord.x && tileCoord.x <= Layers && -Layers < tileCoord.y && tileCoord.y <= Layers)
+            if (-Layers < tileCoord.x && tileCoord.x <= Layers
+                && -Layers < tileCoord.y && tileCoord.y <= Layers)
             {
                 if (i < 4)
                 {
@@ -113,10 +272,9 @@ public class MapBuilder : MonoBehaviour
             tileCoord += diff;
         }
 
-        tileParentTransform.position = new Vector3()
+        tileParentTransform.position = new Vector3
         {
             x = tileParentTransform.position.x,
-            y = HeightOffset,
             z = tileParentTransform.position.z
         };
     }
@@ -140,14 +298,14 @@ public class MapBuilder : MonoBehaviour
 
         Instantiate(
             tile,
-            new Vector3()
+            new Vector3
             {
                 x = (tileCoord.x - 1) * TileSeparation + tileOffset,
                 z = (tileCoord.y - 1) * TileSeparation + tileOffset
             },
-            new Quaternion()
+            new Quaternion
             {
-                eulerAngles = new Vector3()
+                eulerAngles = new Vector3
                 {
                     y = rotation
                 }
@@ -155,27 +313,9 @@ public class MapBuilder : MonoBehaviour
             tileParentTransform.transform);
     }
 
+
     private void PlaceGround()
     {
-        groundTile = Resources.Load<GameObject>(GroundTilePath);
-        if (groundTile == null)
-        {
-            Debug.LogError("Ground prefab not loaded.");
-            return;
-        }
-
-        groundEdge = Resources.Load<GameObject>(GroundEdgePath);
-        if (groundEdge == null)
-        {
-            Debug.LogError("Ground edge prefab not loaded.");
-            return;
-        }
-
-        groundParentTransform = new GameObject(GroundParentName).transform;
-        groundParentTransform.parent = gameObject.transform;
-
-        var groundLayers = (Layers - 1) / 4 + 1;
-
         for (var x = -groundLayers; x < groundLayers; x++)
         {
             for (var z = -groundLayers; z < groundLayers; z++)
@@ -183,150 +323,21 @@ public class MapBuilder : MonoBehaviour
                 PlaceGroundTile(x, z);
             }
         }
-
-        PlaceEdges(groundLayers);
-
-        groundParentTransform.position = new Vector3()
-        {
-            x = groundParentTransform.position.x,
-            y = HeightOffset,
-            z = groundParentTransform.position.z
-        };
     }
 
     private void PlaceGroundTile(int groundX, int groundZ)
     {
         Instantiate(
             groundTile,
-            new Vector3()
+            new Vector3
             {
-                x = 144 * groundX + 74,
-                y = GroundHeight,
-                z = 144 * groundZ + 70
+                x = groundX * 144 + 72,
+                z = groundZ * 144 + 72
             },
             Quaternion.identity,
             groundParentTransform.transform);
     }
 
-    private void PlaceEdges(int groundLayers)
-    {
-        var edgeSize = 0.4f;
-        groundWidth = groundLayers * 288 + 4;
-        var edgeScale = new Vector3()
-        {
-            x = groundWidth / 10f,
-            y = edgeSize,
-            z = edgeSize
-        };
-
-        //top edge
-        var topEdgeObject = Instantiate(
-            groundEdge,
-            new Vector3()
-            {
-                y = GroundHeight,
-                z = groundLayers * 144
-            },
-            Quaternion.identity,
-            groundParentTransform.transform);
-        topEdgeObject.transform.localScale = edgeScale;
-
-        //left edge
-        var leftEdgeObject = Instantiate(
-            groundEdge,
-            new Vector3()
-            {
-                x = -groundLayers * 144,
-                y = GroundHeight
-            },
-            new Quaternion()
-            {
-                eulerAngles = new Vector3()
-                {
-                    y = -90f
-                }
-            },
-            groundParentTransform.transform);
-        leftEdgeObject.transform.localScale = edgeScale;
-    }
-
-    private void PlaceSurround()
-    {
-        surroundParentTransform = new GameObject(SurroundParentName).transform;
-        surroundParentTransform.parent = gameObject.transform;
-
-        surroundWall = Resources.Load<GameObject>(SurroundPath);
-        if (surroundWall == null)
-        {
-            Debug.LogError("Surround wall prefab not loaded.");
-            return;
-        }
-
-        var halfSurroundWidth = groundWidth / 2;
-
-        //top
-        PlaceWall(0, halfSurroundWidth, 180f);
-
-        //bottom
-        PlaceWall(0, -halfSurroundWidth, 0f);
-
-        //left
-        PlaceWall(-halfSurroundWidth, 0, 90f);
-
-        //right
-        PlaceWall(halfSurroundWidth, 0, -90f);
-    }
-
-    private void PlaceWall(int wallX, int wallZ, float rotation)
-    {
-        var wallScale = new Vector3()
-        {
-            x = WallHeight,
-            y = groundWidth,
-            z = 1
-        };
-
-        var surroundWallObjectVisible = Instantiate(
-            surroundWall,
-            new Vector3()
-            {
-                x = wallX,
-                y = WallHeight / 2,
-                z = wallZ
-            },
-            new Quaternion()
-            {
-                eulerAngles = new Vector3()
-                {
-                    x = 180,
-                    y = rotation,
-                    z = -90
-                }
-            },
-            surroundParentTransform.transform);
-        surroundWallObjectVisible.transform.localScale = wallScale;
-
-        var surroundWallObjectInvisible = Instantiate(
-            surroundWall,
-            new Vector3()
-            {
-                x = wallX,
-                y = WallHeight * 3 / 2,
-                z = wallZ
-            },
-            new Quaternion()
-            {
-                eulerAngles = new Vector3()
-                {
-                    x = 180,
-                    y = rotation,
-                    z = -90
-                }
-            },
-            surroundParentTransform.transform);
-        surroundWallObjectInvisible.transform.localScale = wallScale;
-        surroundWallObjectInvisible.GetComponent<Renderer>().enabled = false;
-    }
 
     private void MakeLevelObjectStatic()
     {
@@ -356,12 +367,6 @@ public class MapBuilder : MonoBehaviour
             }
 
             if (child.gameObject.name.Contains(SurroundParentName))
-            {
-                childrenToDestroy.Enqueue(child.gameObject);
-                continue;
-            }
-
-            if (child.gameObject.name.Contains(CubeParentName))
             {
                 childrenToDestroy.Enqueue(child.gameObject);
                 continue;

--- a/workers/unity/Assets/Fps/Scripts/Editor/MapBuilderInspector.cs
+++ b/workers/unity/Assets/Fps/Scripts/Editor/MapBuilderInspector.cs
@@ -25,8 +25,7 @@ public class MapBuilderInspector : Editor
 
         if (GUILayout.Button("Generate Map"))
         {
-            myTarget.Clean();
-            myTarget.Build();
+            myTarget.CleanAndBuild();
         }
 
         if (GUILayout.Button("Clean Map"))


### PR DESCRIPTION
- Modified Edge prefab to use Quads instead of Planes (uses just 2 tris instead of 200), updated placement logic to compensate
- Map edges now have thick walls instead of paper-thin ones ('Corner' prefab added to simplify logic of placing corners in)
- Map edges are now made up multiple pieces instead of one, potentially very very wide, piece. (Could cause collision issues
- Maps now build around the MapBuilder object instead of at origin
- All resource loading now handled in one place, and build process fails early if resource loading fails.
- Some var renaming + tidy up with current cleanup rules