### PR TITLE
Use the new Runtime by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Updated all the launch configs to use the new Runtime.
+
 ### Fixed
 
 - Simulated Players can now rotate about the X axis, enabling them to shoot targets above or below the plane they are on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Updated all the launch configs to use the new Runtime.
+- Updated all the launch configs to better match the world sizes and to use the new Runtime.
 
 ### Fixed
 

--- a/cloud_launch_large.json
+++ b/cloud_launch_large.json
@@ -1,18 +1,36 @@
 {
-  "template": "medium_small",
+  "template": "medium_small_entity_db_v2",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {
       "snapshotWritePeriodSeconds": 0
     },
     "dimensions": {
-      "xMeters": 1600,
-      "zMeters": 1600
+      "xMeters": 900,
+      "zMeters": 900
     },
     "legacy_flags": [
       {
         "name": "max_bridge_module_load",
         "value": "500"
+      }
+    ]
+  },
+  "load_balancing": {
+    "layer_configurations": [
+      {
+        "layer": "UnityGameLogic",
+        "rectangle_grid": {
+          "cols": 2,
+          "rows": 2
+        }
+      },
+      {
+        "layer": "SimulatedPlayerCoordinator",
+        "rectangle_grid": {
+          "cols": 4,
+          "rows": 5
+        }
       }
     ]
   },
@@ -29,30 +47,7 @@
         {
           "all": {}
         }
-      ],
-      "load_balancing": {
-        "points_of_interest": {
-          "num_workers": 4,
-          "points": [
-            {
-              "x": -450,
-              "z": -450
-            },
-            {
-              "x": 450,
-              "z": -450
-            },
-            {
-              "x": 450,
-              "z": 450
-            },
-            {
-              "x": -450,
-              "z": 450
-            }
-          ]
-        }
-      }
+      ]
     },
     {
       "worker_type": "SimulatedPlayerCoordinator",
@@ -74,94 +69,7 @@
         {
           "all": {}
         }
-      ],
-      "load_balancing": {
-        "points_of_interest": {
-          "num_workers": 20,
-          "points": [
-            {
-              "x": 0,
-              "z": 0
-            },
-            {
-              "x": 10,
-              "z": 0
-            },
-            {
-              "x": 20,
-              "z": 0
-            },
-            {
-              "x": 30,
-              "z": 0
-            },
-            {
-              "x": 40,
-              "z": 0
-            },
-            {
-              "x": 0,
-              "z": 10
-            },
-            {
-              "x": 10,
-              "z": 10
-            },
-            {
-              "x": 20,
-              "z": 10
-            },
-            {
-              "x": 30,
-              "z": 10
-            },
-            {
-              "x": 40,
-              "z": 10
-            },
-            {
-              "x": 0,
-              "z": 20
-            },
-            {
-              "x": 10,
-              "z": 20
-            },
-            {
-              "x": 20,
-              "z": 20
-            },
-            {
-              "x": 30,
-              "z": 20
-            },
-            {
-              "x": 40,
-              "z": 20
-            },
-            {
-              "x": 0,
-              "z": 30
-            },
-            {
-              "x": 10,
-              "z": 30
-            },
-            {
-              "x": 20,
-              "z": 30
-            },
-            {
-              "x": 30,
-              "z": 30
-            },
-            {
-              "x": 40,
-              "z": 30
-            }
-          ]
-        }
-      }
+      ]
     },
     {
       "worker_type": "UnityClient",

--- a/cloud_launch_small.json
+++ b/cloud_launch_small.json
@@ -1,14 +1,30 @@
 {
-  "template": "small",
+  "template": "small_entity_db_v2",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {
       "snapshotWritePeriodSeconds": 0
     },
     "dimensions": {
-      "xMeters": 500,
-      "zMeters": 500
+      "xMeters": 300,
+      "zMeters": 300
     }
+  },
+  "load_balancing": {
+    "layer_configurations": [
+      {
+        "layer": "UnityGameLogic",
+        "hex_grid": {
+          "num_workers": 1
+        }
+      },
+      {
+        "layer": "SimulatedPlayerCoordinator",
+        "hex_grid": {
+          "num_workers": 1
+        }
+      }
+    ]
   },
   "workers": [
     {
@@ -23,12 +39,7 @@
         {
           "all": {}
         }
-      ],
-      "load_balancing": {
-        "auto_hex_grid": {
-          "num_workers": 1
-        }
-      }
+      ]
     },
     {
       "worker_type": "SimulatedPlayerCoordinator",
@@ -50,12 +61,7 @@
         {
           "all": {}
         }
-      ],
-      "load_balancing": {
-        "auto_hex_grid": {
-          "num_workers": 1
-        }
-      }
+      ]
     },
     {
       "worker_type": "UnityClient",

--- a/default_launch.json
+++ b/default_launch.json
@@ -1,18 +1,31 @@
 {
-  "template": "small",
+  "template": "small_entity_db_v2",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {
       "snapshotWritePeriodSeconds": 0
     },
     "dimensions": {
-      "xMeters": 500,
-      "zMeters": 500
-    },
-    "legacy_flags": [
+      "xMeters": 300,
+      "zMeters": 300
+    }
+  },
+  "load_balancing": {
+    "layer_configurations": [
       {
-        "name": "bridge_qos_max_timeout",
-        "value": "0"
+        "layer": "UnityGameLogic",
+        "points_of_interest": {
+          "num_workers": 1,
+          "points": [
+            {
+              "x": 0,
+              "z": 0
+            }
+          ]
+        },
+        "options": {
+          "manual_worker_connection_only": true
+        }
       }
     ]
   },
@@ -29,10 +42,7 @@
         {
           "all": {}
         }
-      ],
-      "load_balancing": {
-        "singleton_worker": {}
-      }
+      ]
     },
     {
       "worker_type": "UnityClient",
@@ -46,10 +56,7 @@
         {
           "all": {}
         }
-      ],
-      "load_balancing": {
-        "singleton_worker": {}
-      }
+      ]
     },
     {
       "worker_type": "SimulatedPlayer",
@@ -63,10 +70,7 @@
         {
           "all": {}
         }
-      ],
-      "load_balancing": {
-        "singleton_worker": {}
-      }
+      ]
     },
     {
       "worker_type": "SimulatedPlayerCoordinator",
@@ -80,10 +84,7 @@
         {
           "all": {}
         }
-      ],
-      "load_balancing": {
-        "singleton_worker": {}
-      }
+      ]
     }
   ]
 }

--- a/workers/unity/spatialos.SimulatedPlayerCoordinator.worker.json
+++ b/workers/unity/spatialos.SimulatedPlayerCoordinator.worker.json
@@ -18,7 +18,7 @@
   "bridge": {
     "worker_attribute_set": {
       "attributes": [
-          "SimulatedPlayerCoordinator"
+        "SimulatedPlayerCoordinator"
       ]
     },
     "entity_interest": {

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -18,7 +18,7 @@
   "bridge": {
     "worker_attribute_set": {
       "attributes": [
-          "UnityGameLogic"
+        "UnityGameLogic"
       ]
     },
     "entity_interest": {


### PR DESCRIPTION
#### Description
Update launch configurations to use the new Runtime.

Also updated dimensions for deployments to better match world sizes (300x300 for local/small, 900x900 for large deployments).

Local + small deployments use a 4-layer world, which has edge length of 292m. Calculated by: (4*2*36)+4. The larger deployment uses a 12-layer world, which has edge length of 868m (12*2*36)+4. This means that the spatial world sizes defined in the launch configs only need to be 300x300 and 900x900.

#### Tests
- [x] run locally
- [x] run small cloud deployment
- [x] run large cloud deployment

#### Documentation
n/a

**Did you remember a changelog entry?**
I have now

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
