### PR TITLE
Deployment Launcher tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 - Reduced `fps_simulated_players_creation_interval` from 60 to 5.
+- Disabled the `Generate Map` button in the MapBuilder window if `MapBuilderSettings` is not set.
 
 ## `0.1.5` - 2019-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Tweaked the Deployment Launcher window:
-    - Added ability to choose deployment region (US, EU, AP).
+    - Added ability to choose deployment region (US, EU).
     - Added ability to force-upload an assembly.
     - Automatically open the SpatialOS Console page for a launched deployment.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Added
+
+- Tweaked the Deployment Launcher window:
+    - Added ability to choose deployment region (US, EU, AP).
+    - Added ability to force-upload an assembly.
+    - Automatically open the SpatialOS Console page for a launched deployment.
+
+### Changed
+
+- Reduced `fps_simulated_players_creation_interval` from 60 to 5.
+
 ## `0.1.5` - 2019-02-21
 
 ### Added

--- a/cloud_launch_large_sim_players.json
+++ b/cloud_launch_large_sim_players.json
@@ -41,7 +41,7 @@
         },
         {
           "name": "fps_simulated_players_creation_interval",
-          "value": "60"
+          "value": "5"
         }
       ],
       "permissions": [

--- a/workers/unity/Assets/Fps/Scripts/Editor/MapBuilderVisualisationWindow.cs
+++ b/workers/unity/Assets/Fps/Scripts/Editor/MapBuilderVisualisationWindow.cs
@@ -66,12 +66,13 @@ namespace Fps.Editor
                 mapBuilderSettings,
                 typeof(MapBuilderSettings));
 
+            EditorGUI.BeginDisabledGroup(mapBuilderSettings == null);
             if (GUILayout.Button("Generate Map"))
             {
                 if (numTiles < WarnTilesThreshold
                     || GetGenerationUserConfirmation(numTiles))
                 {
-                    if (mapBuilder == null || mapBuilder.InvalidMapBuilder)
+                    if (mapBuilderSettings == null || mapBuilder == null || mapBuilder.InvalidMapBuilder)
                     {
                         SetupMapBuilder();
                     }
@@ -79,6 +80,8 @@ namespace Fps.Editor
                     mapBuilder.CleanAndBuild(layerCount, seed, emptyTileChance);
                 }
             }
+
+            EditorGUI.EndDisabledGroup();
 
             EditorGUI.BeginDisabledGroup(mapBuilder == null);
             if (GUILayout.Button("Clear Map"))

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
@@ -70,24 +70,22 @@ namespace Improbable
 
         private static int CreateDeployment(string[] args)
         {
-            bool launchSimPlayerDeployment = args.Length == 10;
+            bool launchSimPlayerDeployment = args.Length == 9;
 
             var projectName = args[1];
             var assemblyName = args[2];
             var mainDeploymentName = args[3];
             var mainDeploymentJson = args[4];
             var mainDeploymentSnapshotFilePath = args[5];
-            var mainDeploymentRegionCode = args[6];
+            var deploymentRegionCode = args[6];
 
             var simDeploymentName = string.Empty;
             var simDeploymentJson = string.Empty;
-            var simDeploymentRegionCode = String.Empty;
 
             if (launchSimPlayerDeployment)
             {
                 simDeploymentName = args[7];
                 simDeploymentJson = args[8];
-                simDeploymentRegionCode = args[9];
             }
 
             // Create service clients.
@@ -117,7 +115,7 @@ namespace Improbable
                     Name = mainDeploymentName,
                     ProjectName = projectName,
                     StartingSnapshotId = mainSnapshotId,
-                    RegionCode = mainDeploymentRegionCode
+                    RegionCode = deploymentRegionCode
                 };
 
                 if (launchSimPlayerDeployment)
@@ -181,7 +179,7 @@ namespace Improbable
                         },
                         Name = simDeploymentName,
                         ProjectName = projectName,
-                        RegionCode = simDeploymentRegionCode
+                        RegionCode = deploymentRegionCode
                     };
 
                     simDeploymentConfig.Tag.Add("simulated_clients");
@@ -267,7 +265,7 @@ namespace Improbable
         {
             Console.WriteLine("Usage:");
             Console.WriteLine(
-                "DeploymentManager create <project-name> <assembly-name> <main-deployment-name> <main-deployment-json> <main-deployment-snapshot> <main-deployment-region> [<sim-deployment-name> <sim-deployment-json> <sim-deployment-region>]");
+                "DeploymentManager create <project-name> <assembly-name> <main-deployment-name> <main-deployment-json> <main-deployment-snapshot> <main-deployment-region> [<sim-deployment-name> <sim-deployment-json>]");
             Console.WriteLine("DeploymentManager stop <project-name> <deployment-id>");
             Console.WriteLine("DeploymentManager list <project-name>");
         }
@@ -275,7 +273,7 @@ namespace Improbable
         private static int Main(string[] args)
         {
             if (args.Length == 0 ||
-                args[0] == "create" && (args.Length != 10 && args.Length != 7) ||
+                args[0] == "create" && (args.Length != 9 && args.Length != 7) ||
                 args[0] == "stop" && args.Length != 3 ||
                 args[0] == "list" && args.Length != 2)
             {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
@@ -70,21 +70,24 @@ namespace Improbable
 
         private static int CreateDeployment(string[] args)
         {
-            bool launchSimPlayerDeployment = args.Length == 8;
+            bool launchSimPlayerDeployment = args.Length == 10;
 
             var projectName = args[1];
             var assemblyName = args[2];
             var mainDeploymentName = args[3];
             var mainDeploymentJson = args[4];
             var mainDeploymentSnapshotFilePath = args[5];
+            var mainDeploymentRegionCode = args[6];
 
             var simDeploymentName = string.Empty;
             var simDeploymentJson = string.Empty;
+            var simDeploymentRegionCode = String.Empty;
 
             if (launchSimPlayerDeployment)
             {
-                simDeploymentName = args[6];
-                simDeploymentJson = args[7];
+                simDeploymentName = args[7];
+                simDeploymentJson = args[8];
+                simDeploymentRegionCode = args[9];
             }
 
             // Create service clients.
@@ -113,7 +116,8 @@ namespace Improbable
                     },
                     Name = mainDeploymentName,
                     ProjectName = projectName,
-                    StartingSnapshotId = mainSnapshotId
+                    StartingSnapshotId = mainSnapshotId,
+                    RegionCode = mainDeploymentRegionCode
                 };
 
                 if (launchSimPlayerDeployment)
@@ -176,7 +180,8 @@ namespace Improbable
                             ConfigJson = simWorkerConfigJson
                         },
                         Name = simDeploymentName,
-                        ProjectName = projectName
+                        ProjectName = projectName,
+                        RegionCode = simDeploymentRegionCode
                     };
 
                     simDeploymentConfig.Tag.Add("simulated_clients");
@@ -262,7 +267,7 @@ namespace Improbable
         {
             Console.WriteLine("Usage:");
             Console.WriteLine(
-                "DeploymentManager create <project-name> <assembly-name> <main-deployment-name> <main-deployment-json> <main-deployment-snapshot> [<sim-deployment-name> <sim-deployment-json>]");
+                "DeploymentManager create <project-name> <assembly-name> <main-deployment-name> <main-deployment-json> <main-deployment-snapshot> <main-deployment-region> [<sim-deployment-name> <sim-deployment-json> <sim-deployment-region>]");
             Console.WriteLine("DeploymentManager stop <project-name> <deployment-id>");
             Console.WriteLine("DeploymentManager list <project-name>");
         }
@@ -270,7 +275,7 @@ namespace Improbable
         private static int Main(string[] args)
         {
             if (args.Length == 0 ||
-                args[0] == "create" && (args.Length != 8 && args.Length != 6) ||
+                args[0] == "create" && (args.Length != 10 && args.Length != 7) ||
                 args[0] == "stop" && args.Length != 3 ||
                 args[0] == "list" && args.Length != 2)
             {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncher.cs
@@ -358,7 +358,10 @@ namespace Improbable.Gdk.DeploymentManager
                     if (processResult.ExitCode == 0)
                     {
                         Application.OpenURL(string.Format(ConsoleURLFormat, projectName, deploymentName));
-                        Application.OpenURL(string.Format(ConsoleURLFormat, projectName, simPlayerDeploymentName));
+                        if (simPlayerDeploymentEnabled)
+                        {
+                            Application.OpenURL(string.Format(ConsoleURLFormat, projectName, simPlayerDeploymentName));
+                        }
                     }
 
                     return processResult.ExitCode != 0;

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncher.cs
@@ -52,8 +52,7 @@ namespace Improbable.Gdk.DeploymentManager
         internal enum DeploymentRegionCode
         {
             US,
-            EU,
-            AP
+            EU
         }
 
         internal class DeploymentEditorWindow : EditorWindow
@@ -71,8 +70,7 @@ namespace Improbable.Gdk.DeploymentManager
             private bool simPlayerDeploymentEnabled;
             private bool simPlayerCustomDeploymentNameEnabled;
 
-            private DeploymentRegionCode mainDeploymentRegionCode = DeploymentRegionCode.US;
-            private DeploymentRegionCode simPlayerDeploymentRegionCode = DeploymentRegionCode.US;
+            private DeploymentRegionCode deploymentRegionCode = DeploymentRegionCode.US;
 
             private List<DeploymentInfo> deploymentList;
             private int selectedDeployment;
@@ -131,8 +129,8 @@ namespace Improbable.Gdk.DeploymentManager
                 deploymentName = EditorGUILayout.TextField("Deployment Name", deploymentName).Trim();
                 snapshotPath = EditorGUILayout.TextField("Snapshot File", snapshotPath);
                 mainLaunchJson = EditorGUILayout.TextField("Launch Config File", mainLaunchJson);
-                mainDeploymentRegionCode = (DeploymentRegionCode) EditorGUILayout.EnumPopup(
-                    "Deployment Region", mainDeploymentRegionCode);
+                deploymentRegionCode = (DeploymentRegionCode) EditorGUILayout.EnumPopup(
+                    "Deployment Region", deploymentRegionCode);
                 using (var simPlayerDeploymentScope =
                     new EditorGUILayout.ToggleGroupScope("Enable Simulated Players", simPlayerDeploymentEnabled))
                 {
@@ -148,8 +146,6 @@ namespace Improbable.Gdk.DeploymentManager
                     }
 
                     simPlayerLaunchJson = EditorGUILayout.TextField("Launch Config File", simPlayerLaunchJson);
-                    simPlayerDeploymentRegionCode = (DeploymentRegionCode) EditorGUILayout.EnumPopup(
-                        "Deployment Region", simPlayerDeploymentRegionCode);
                 }
 
                 var validLaunchParameters = true;
@@ -336,15 +332,14 @@ namespace Improbable.Gdk.DeploymentManager
                         deploymentName,
                         Path.Combine(ProjectRootPath, mainLaunchJson),
                         Path.Combine(ProjectRootPath, snapshotPath),
-                        mainDeploymentRegionCode.ToString()
+                        deploymentRegionCode.ToString()
                     };
                     if (simPlayerDeploymentEnabled)
                     {
                         arguments.AddRange(new List<string>
                         {
                             simPlayerDeploymentName,
-                            Path.Combine(ProjectRootPath, simPlayerLaunchJson),
-                            simPlayerDeploymentRegionCode.ToString()
+                            Path.Combine(ProjectRootPath, simPlayerLaunchJson)
                         });
                     }
 


### PR DESCRIPTION
#### Description
- added ability to choose deployment region (US, EU) [UTY-1819]
- added ability to force-upload assembly [UTY-1817]
- automatically open console pages when deployment(s) ready [UTY-1779]
	- only opens simplayer console page if simplayers are enabled
- reduced `fps_simulated_players_creation_interval` from 60 to 5 [UTY-1801]
- disabled the `Generate Map` button in the MapBuilder window if `MapBuilderSettings` is not set [UTY-1825]

#### Tests
- did it in editor
- logged into the created deployments

#### Documentation
- changelog 👍 
- docs PR: https://github.com/spatialos/gdk-for-unity/pull/797

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
