### PR TITLE
Fixing simulated players for development scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 	- Now make use of nested prefabs.
 	- Completely new set of default tiles used to populate the world
 - Updated the build configuration asset
+- Reduced the amount of health that gets regenerated. 
 
 ### Fixed
 

--- a/workers/unity/Assets/Fps/Scenes/FPS-Development.unity
+++ b/workers/unity/Assets/Fps/Scenes/FPS-Development.unity
@@ -121,7 +121,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4105036026752776, guid: 928af08170e7d0243a977f4f26fe42a0, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 5000
       objectReference: {fileID: 0}
     - target: {fileID: 4105036026752776, guid: 928af08170e7d0243a977f4f26fe42a0, type: 3}
       propertyPath: m_LocalPosition.y
@@ -129,7 +129,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4105036026752776, guid: 928af08170e7d0243a977f4f26fe42a0, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 200
       objectReference: {fileID: 0}
     - target: {fileID: 4105036026752776, guid: 928af08170e7d0243a977f4f26fe42a0, type: 3}
       propertyPath: m_LocalRotation.x
@@ -502,6 +502,37 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de9de090270a7f64b91c24e64242f1aa, type: 3}
+--- !u!1 &1274432719
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1274432720}
+  m_Layer: 0
+  m_Name: FPS-Level_Visualisation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &1274432720
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1274432719}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1670248492}
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1275767664
 GameObject:
   m_ObjectHideFlags: 0
@@ -1165,6 +1196,50 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1541234925}
   m_Mesh: {fileID: 4300002, guid: c6af15f8d59b4264ebc70ff998901408, type: 3}
+--- !u!1 &1670248491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1670248492}
+  - component: {fileID: 1670248493}
+  m_Layer: 0
+  m_Name: SpawnPointSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &1670248492
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1670248491}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1274432720}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1670248493
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1670248491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 02ea3b8bfd534d244806cdc6cbe31160, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapsToGround: 1
 --- !u!114 &1721904475 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114220086504602960, guid: 928af08170e7d0243a977f4f26fe42a0,
@@ -1245,11 +1320,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4527984774241536, guid: a18c738cbcda9914591d9af24a618907, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5000
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527984774241536, guid: a18c738cbcda9914591d9af24a618907, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 200
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527984774241536, guid: a18c738cbcda9914591d9af24a618907, type: 3}
       propertyPath: m_LocalPosition.z

--- a/workers/unity/Assets/Fps/Scripts/Config/PlayerHealthSettings.cs
+++ b/workers/unity/Assets/Fps/Scripts/Config/PlayerHealthSettings.cs
@@ -6,7 +6,7 @@
 
         public static float RegenAfterDamageCooldown = 5.0f;
         public static float RegenInterval = 0.2f;
-        public static float RegenAmount = 5.0f;
+        public static float RegenAmount = 2.0f;
         public static float SpatialCooldownSyncInterval = 0.5f;
     }
 }

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/ClientWorkerHandler.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/ClientWorkerHandler.cs
@@ -48,7 +48,7 @@ namespace Fps
                 Destroy(currentClientWorker);
             }
 
-            currentClientWorker = Instantiate(clientWorkerPrefab);
+            currentClientWorker = Instantiate(clientWorkerPrefab, transform.position, Quaternion.identity);
             workerConnector = currentClientWorker.GetComponent<WorkerConnector>();
             tileProvider = workerConnector as ITileProvider;
             connectionController = currentClientWorker.GetComponent<ConnectionController>();


### PR DESCRIPTION
#### Description
The navmesh was applied to the client world instead of the simulated player world.
Swapped the position of the two worlds to ensure the navmesh gets applied to the correct world.

Reduced health regen a bit as it was nearly impossible to die

#### Tests
ran it in the editor.