### PR TITLE
Fixed Development scene terrain and bullets remapping

### DIFF
--- a/workers/unity/Assets/Fps/Scenes/FPS-Development.unity
+++ b/workers/unity/Assets/Fps/Scenes/FPS-Development.unity
@@ -311,7 +311,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 286530406}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 5000, y: 0, z: 200}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children:
   - {fileID: 1979837694}

--- a/workers/unity/Packages/com.improbable.gdk.guns/Behaviours/ShotRenderer.cs
+++ b/workers/unity/Packages/com.improbable.gdk.guns/Behaviours/ShotRenderer.cs
@@ -51,6 +51,7 @@ namespace Improbable.Gdk.Guns
 
         private GunSettings gunSettings;
         private GunSocket gunSocket;
+        private LinkedEntityComponent spatial;
 
         private UnityEngine.Transform GunBarrel => gunSocket.Gun.Barrel != null
             ? gunSocket.Gun.Barrel
@@ -65,6 +66,7 @@ namespace Improbable.Gdk.Guns
         private void OnEnable()
         {
             shooting.OnShotsEvent += ShotFired;
+            spatial = GetComponent<LinkedEntityComponent>();
         }
 
         private void OnDisable()
@@ -80,7 +82,7 @@ namespace Improbable.Gdk.Guns
         private void ShotFired(ShotInfo shotInfo)
         {
             var isAiming = gunState.Data.IsAiming;
-            var hitLocation = shotInfo.HitLocation.ToVector3();
+            var hitLocation = shotInfo.HitLocation.ToVector3() + spatial.Worker.Origin;
             var hitSomething = shotInfo.HitSomething;
 
             PlayRecoil(isAiming);


### PR DESCRIPTION
#### Description
Surrounding props are now at the right location
Bullets are now position remapped

#### Tests
Tested in location deployment using the Development scene (where the issue was visible)
