### PR TITLE
Added spawn points to tile prefabs. Made 1 tree taller.

### DIFF
--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Structure_Bunker_A.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Structure_Bunker_A.prefab
@@ -1,5 +1,91 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1780178908502236387
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2682623215216303726}
+  - component: {fileID: 124097248858676292}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2682623215216303726
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1780178908502236387}
+  m_LocalRotation: {x: -0, y: 0.67767453, z: -0, w: 0.735362}
+  m_LocalPosition: {x: 9.26, y: 0, z: 7.51}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8184327945643717433}
+  m_RootOrder: 95
+  m_LocalEulerAnglesHint: {x: 0, y: 85.324005, z: 0}
+--- !u!114 &124097248858676292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1780178908502236387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &3949679032481834416
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6278917458153502804}
+  - component: {fileID: 1007577306496342226}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6278917458153502804
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3949679032481834416}
+  m_LocalRotation: {x: -0, y: 0.72631544, z: -0, w: 0.6873616}
+  m_LocalPosition: {x: 8.96, y: 0, z: -14.97}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8184327945643717433}
+  m_RootOrder: 96
+  m_LocalEulerAnglesHint: {x: 0, y: 93.157005, z: 0}
+--- !u!114 &1007577306496342226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3949679032481834416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4333095445774791081
 GameObject:
   m_ObjectHideFlags: 0
@@ -6326,6 +6412,8 @@ Transform:
   - {fileID: 7725681287696357771}
   - {fileID: 1034260424230586202}
   - {fileID: 5295893007013153064}
+  - {fileID: 2682623215216303726}
+  - {fileID: 6278917458153502804}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6355,7 +6443,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0acc01bb717a0db49aaafaa4d2b8bdbc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TileSize: 32
+  InnerTileSize: 32
   ConnectorLength: 8
   ConnectorDepth: 4
   Color: {r: 0.2, g: 0.7, b: 0.2, a: 0.4}
@@ -7862,20 +7950,20 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1.0000005
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.12499989
+      value: -0.12499984
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.3224998
+      value: 1.5099998
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 2.0049992
+      value: 3.5049987
       objectReference: {fileID: 0}
     - target: {fileID: 4863357189401923865, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
@@ -7907,47 +7995,17 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.0049992
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.12499984
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.5099998
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 3.5049987
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.12499992
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.6349998
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1.0674996
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.12499989
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.94749975
+      value: 2.3224998
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 2.0049992
@@ -7967,6 +8025,21 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.942499
       objectReference: {fileID: 0}
+    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12499993
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.5099998
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5049999
+      objectReference: {fileID: 0}
     - target: {fileID: 4863357190565582310, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7982,20 +8055,35 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.0049992
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.12499993
+      value: -0.12499989
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5099998
+      value: 0.94749975
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.5049999
+      value: 2.0049992
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12499992
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6349998
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.0674996
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 39f66b26fd968b44396dc0db059cb116, type: 3}
@@ -8295,36 +8383,6 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.12999429
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.0000007
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189401923865, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.12999429
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189401923865, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.0000007
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189424579912, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.12999429
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189424579912, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.0000007
-      objectReference: {fileID: 0}
     - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8335,22 +8393,32 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 3.500001
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.12999703
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1.0625005
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189401923865, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.12999429
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189401923865, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0000007
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357189424579912, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12999429
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357189424579912, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0000007
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12999429
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 2.0000007
@@ -8365,6 +8433,16 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.9375007
       objectReference: {fileID: 0}
+    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12999867
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5000004
+      objectReference: {fileID: 0}
     - target: {fileID: 4863357190565582310, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8375,15 +8453,25 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.0000007
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.12999867
+      value: -0.12999429
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.5000004
+      value: 2.0000007
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.12999703
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.0625005
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 39f66b26fd968b44396dc0db059cb116, type: 3}
@@ -8799,15 +8887,15 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.3224998
+      value: 1.5099998
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 2.0049992
+      value: 3.5049987
       objectReference: {fileID: 0}
     - target: {fileID: 4863357189401923865, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
@@ -8829,32 +8917,12 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.0049992
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5099998
+      value: 2.3224998
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357189165040661, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 3.5049987
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.6349998
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1.0674996
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.94749975
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357188784138343, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 2.0049992
@@ -8869,6 +8937,16 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.942499
       objectReference: {fileID: 0}
+    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.5099998
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5049999
+      objectReference: {fileID: 0}
     - target: {fileID: 4863357190565582310, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.y
@@ -8879,15 +8957,25 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.0049992
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5099998
+      value: 0.94749975
       objectReference: {fileID: 0}
-    - target: {fileID: 4863357190533327405, guid: 39f66b26fd968b44396dc0db059cb116,
+    - target: {fileID: 4863357189660205510, guid: 39f66b26fd968b44396dc0db059cb116,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.5049999
+      value: 2.0049992
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6349998
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863357189816771580, guid: 39f66b26fd968b44396dc0db059cb116,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.0674996
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 39f66b26fd968b44396dc0db059cb116, type: 3}

--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Structure_Bunker_B.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Structure_Bunker_B.prefab
@@ -1818,6 +1818,8 @@ Transform:
   - {fileID: 3578435982666295918}
   - {fileID: 7039036606533141495}
   - {fileID: 8873500833558247434}
+  - {fileID: 3782157118897466933}
+  - {fileID: 864236610982392433}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1847,7 +1849,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0acc01bb717a0db49aaafaa4d2b8bdbc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TileSize: 32
+  InnerTileSize: 32
   ConnectorLength: 8
   ConnectorDepth: 4
   Color: {r: 0.2, g: 0.7, b: 0.2, a: 0.4}
@@ -3313,6 +3315,49 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5070146928693567161
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 864236610982392433}
+  - component: {fileID: 5133184096226312565}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &864236610982392433
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5070146928693567161}
+  m_LocalRotation: {x: -0, y: 0.22001542, z: -0, w: 0.9754964}
+  m_LocalPosition: {x: -3.7, y: 0.251, z: 7.21}
+  m_LocalScale: {x: 0.9999996, y: 1, z: 0.9999996}
+  m_Children: []
+  m_Father: {fileID: 2958389877474832033}
+  m_RootOrder: 54
+  m_LocalEulerAnglesHint: {x: 0, y: 25.420002, z: 0}
+--- !u!114 &5133184096226312565
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5070146928693567161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6225947173312308175
 GameObject:
   m_ObjectHideFlags: 0
@@ -3859,6 +3904,49 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &8272323322713421379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3782157118897466933}
+  - component: {fileID: 4235889189750152915}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3782157118897466933
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8272323322713421379}
+  m_LocalRotation: {x: -0, y: 0.96530306, z: -0, w: 0.26113227}
+  m_LocalPosition: {x: -2.616, y: 0.251, z: -7.018}
+  m_LocalScale: {x: 0.9999996, y: 1, z: 0.9999996}
+  m_Children: []
+  m_Father: {fileID: 2958389877474832033}
+  m_RootOrder: 53
+  m_LocalEulerAnglesHint: {x: 0, y: 149.725, z: 0}
+--- !u!114 &4235889189750152915
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8272323322713421379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8395775259659115483
 GameObject:
   m_ObjectHideFlags: 0

--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Structure_Courtyard_A.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Structure_Courtyard_A.prefab
@@ -91,6 +91,49 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &406777750852061124
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1150513581155831746}
+  - component: {fileID: 1033062866132526301}
+  m_Layer: 0
+  m_Name: Spawn (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1150513581155831746
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 406777750852061124}
+  m_LocalRotation: {x: -0, y: 0.99998677, z: -0, w: 0.0051452755}
+  m_LocalPosition: {x: 0.45, y: 0.2, z: -13.34}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6625492909802417862}
+  m_RootOrder: 127
+  m_LocalEulerAnglesHint: {x: 0, y: 179.41, z: 0}
+--- !u!114 &1033062866132526301
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 406777750852061124}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1853559905774406421
 GameObject:
   m_ObjectHideFlags: 0
@@ -455,6 +498,49 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5645614893120589738
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2448429715420798752}
+  - component: {fileID: 8624888636728442902}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2448429715420798752
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5645614893120589738}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.47, y: 0.2, z: -10.89}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6625492909802417862}
+  m_RootOrder: 126
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8624888636728442902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5645614893120589738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6625492908907195521
 GameObject:
   m_ObjectHideFlags: 0
@@ -5080,6 +5166,8 @@ Transform:
   - {fileID: 4821472852467912899}
   - {fileID: 4500519462917071619}
   - {fileID: 2715222635518554175}
+  - {fileID: 2448429715420798752}
+  - {fileID: 1150513581155831746}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5109,7 +5197,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0acc01bb717a0db49aaafaa4d2b8bdbc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TileSize: 32
+  InnerTileSize: 32
   ConnectorLength: 8
   ConnectorDepth: 4
   Color: {r: 0.2, g: 0.7, b: 0.2, a: 0.4}

--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Structure_Large_B.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Structure_Large_B.prefab
@@ -364,6 +364,49 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &2198888075612390451
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3476787262498753510}
+  - component: {fileID: 1316615817133787387}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3476787262498753510
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2198888075612390451}
+  m_LocalRotation: {x: -0, y: 0.54111826, z: -0, w: 0.8409465}
+  m_LocalPosition: {x: 13.01, y: 2, z: 2.51}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8018979963113944717}
+  m_RootOrder: 112
+  m_LocalEulerAnglesHint: {x: 0, y: 65.520004, z: 0}
+--- !u!114 &1316615817133787387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2198888075612390451}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2444457122331274808
 GameObject:
   m_ObjectHideFlags: 0
@@ -548,6 +591,49 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 14
   m_Mesh: {fileID: 4300006, guid: f24cc58035b965a47b2d448ebc09539e, type: 3}
+--- !u!1 &3311856349568550791
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8746290140341150291}
+  - component: {fileID: 7564973513398212147}
+  m_Layer: 0
+  m_Name: Spawn (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8746290140341150291
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3311856349568550791}
+  m_LocalRotation: {x: -0, y: 0.79551095, z: -0, w: -0.60593927}
+  m_LocalPosition: {x: -14.64, y: 2, z: -4.91}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8018979963113944717}
+  m_RootOrder: 113
+  m_LocalEulerAnglesHint: {x: 0, y: 254.59299, z: 0}
+--- !u!114 &7564973513398212147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3311856349568550791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3438684099086000580
 GameObject:
   m_ObjectHideFlags: 0
@@ -4444,6 +4530,8 @@ Transform:
   - {fileID: 3705005693755752863}
   - {fileID: 8315357634655418762}
   - {fileID: 1176902058748941813}
+  - {fileID: 3476787262498753510}
+  - {fileID: 8746290140341150291}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4473,7 +4561,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0acc01bb717a0db49aaafaa4d2b8bdbc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TileSize: 32
+  InnerTileSize: 32
   ConnectorLength: 8
   ConnectorDepth: 4
   Color: {r: 0.2, g: 0.7, b: 0.2, a: 0.4}

--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Wild_A.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Wild_A.prefab
@@ -39,6 +39,7 @@ Transform:
   - {fileID: 6468941143304865778}
   - {fileID: 4574652232702814130}
   - {fileID: 1929334731304826728}
+  - {fileID: 8753735529161446959}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -68,7 +69,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0acc01bb717a0db49aaafaa4d2b8bdbc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TileSize: 32
+  InnerTileSize: 32
   ConnectorLength: 8
   ConnectorDepth: 4
   Color: {r: 0.2, g: 0.7, b: 0.2, a: 0.4}
@@ -285,6 +286,49 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &8334637233731364688
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8753735529161446959}
+  - component: {fileID: 453992509401491382}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8753735529161446959
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8334637233731364688}
+  m_LocalRotation: {x: -0, y: 0.39142433, z: -0, w: 0.9202103}
+  m_LocalPosition: {x: 2.88, y: 3, z: -5.8}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4019141152831628}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 46.086002, z: 0}
+--- !u!114 &453992509401491382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8334637233731364688}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &910908956976379490
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -360,7 +404,7 @@ PrefabInstance:
     - target: {fileID: 3735840520979517904, guid: 15e7f133031e3cb438a9b8ad197a1666,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 1
+      value: 1.2
       objectReference: {fileID: 0}
     - target: {fileID: 3735840520979517904, guid: 15e7f133031e3cb438a9b8ad197a1666,
         type: 3}
@@ -382,6 +426,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4019141152831628}
     m_Modifications:
+    - target: {fileID: 6534165231605766947, guid: e5c1b3591499dc94cb92056f1ff716f1,
+        type: 3}
+      propertyPath: m_Name
+      value: CoverGroup 5
+      objectReference: {fileID: 0}
     - target: {fileID: 4079759058928164544, guid: e5c1b3591499dc94cb92056f1ff716f1,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -436,11 +485,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6534165231605766947, guid: e5c1b3591499dc94cb92056f1ff716f1,
-        type: 3}
-      propertyPath: m_Name
-      value: CoverGroup 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e5c1b3591499dc94cb92056f1ff716f1, type: 3}
@@ -622,6 +666,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4019141152831628}
     m_Modifications:
+    - target: {fileID: 6157027414827820946, guid: ec9b5bf2f3082a74da4d35f2419c701b,
+        type: 3}
+      propertyPath: m_Name
+      value: CoverGroup 3
+      objectReference: {fileID: 0}
     - target: {fileID: 3347372278966110664, guid: ec9b5bf2f3082a74da4d35f2419c701b,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -676,11 +725,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6157027414827820946, guid: ec9b5bf2f3082a74da4d35f2419c701b,
-        type: 3}
-      propertyPath: m_Name
-      value: CoverGroup 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ec9b5bf2f3082a74da4d35f2419c701b, type: 3}

--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Wild_B.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Wild_B.prefab
@@ -226,6 +226,7 @@ Transform:
   - {fileID: 6966097675851693173}
   - {fileID: 638853770558849598}
   - {fileID: 4356718557128452578}
+  - {fileID: 6935063686745368454}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -259,6 +260,49 @@ MonoBehaviour:
   ConnectorLength: 8
   ConnectorDepth: 4
   Color: {r: 0.2, g: 0.7, b: 0.2, a: 0.4}
+--- !u!1 &1703643761049669336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6935063686745368454}
+  - component: {fileID: 4957245879460897107}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6935063686745368454
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1703643761049669336}
+  m_LocalRotation: {x: -0, y: 0.39142433, z: -0, w: 0.9202103}
+  m_LocalPosition: {x: -1.32, y: 6, z: -8.99}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4173280778572240}
+  m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 46.086002, z: 0}
+--- !u!114 &4957245879460897107
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1703643761049669336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2152494792083441346
 GameObject:
   m_ObjectHideFlags: 0
@@ -811,6 +855,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4173280778572240}
     m_Modifications:
+    - target: {fileID: 6157027414827820946, guid: ec9b5bf2f3082a74da4d35f2419c701b,
+        type: 3}
+      propertyPath: m_Name
+      value: CoverGroup 3
+      objectReference: {fileID: 0}
     - target: {fileID: 3347372278966110664, guid: ec9b5bf2f3082a74da4d35f2419c701b,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -865,11 +914,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6157027414827820946, guid: ec9b5bf2f3082a74da4d35f2419c701b,
-        type: 3}
-      propertyPath: m_Name
-      value: CoverGroup 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ec9b5bf2f3082a74da4d35f2419c701b, type: 3}
@@ -1051,6 +1095,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4173280778572240}
     m_Modifications:
+    - target: {fileID: 727688637455664649, guid: 15e7f133031e3cb438a9b8ad197a1666,
+        type: 3}
+      propertyPath: m_Name
+      value: Tree_Large
+      objectReference: {fileID: 0}
     - target: {fileID: 3735840520979517904, guid: 15e7f133031e3cb438a9b8ad197a1666,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1105,11 +1154,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 727688637455664649, guid: 15e7f133031e3cb438a9b8ad197a1666,
-        type: 3}
-      propertyPath: m_Name
-      value: Tree_Large
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 15e7f133031e3cb438a9b8ad197a1666, type: 3}

--- a/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Wild_C.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/Level/Tiles/Tile_Wild_C.prefab
@@ -225,6 +225,7 @@ Transform:
   - {fileID: 6058707076797459084}
   - {fileID: 5460885240656586169}
   - {fileID: 2421564290439551634}
+  - {fileID: 4454946403254744060}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -254,7 +255,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0acc01bb717a0db49aaafaa4d2b8bdbc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TileSize: 32
+  InnerTileSize: 32
   ConnectorLength: 8
   ConnectorDepth: 4
   Color: {r: 0.2, g: 0.7, b: 0.2, a: 0.4}
@@ -531,6 +532,49 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &8778836527025338029
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4454946403254744060}
+  - component: {fileID: 6874098414122063241}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4454946403254744060
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8778836527025338029}
+  m_LocalRotation: {x: -0, y: 0.39142433, z: -0, w: 0.9202103}
+  m_LocalPosition: {x: -5.6, y: 4, z: 6.72}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4287935734642948}
+  m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: 0, y: 46.086002, z: 0}
+--- !u!114 &6874098414122063241
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8778836527025338029}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd12cde1ebf5034ebd7051385e8bac5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8779662802061535580
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
**Non-time-critical**, unless we absolutely need more balanced spawn position coverage.

- Added spawn points to some tiles that previously had none.
- Made 1 tree taller to make it easier to walk under (navmesh unaffected).

Before/after top-down spawn position coverage:
![image](https://user-images.githubusercontent.com/39483705/54274968-56bf8300-4581-11e9-9d56-847276b5b16f.png)
