### PR TITLE
Bugfix/ads camera offset after death

### DIFF
--- a/workers/unity/Assets/Fps/Resources/Prefabs/MobileClient/Authoritative/Player.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/MobileClient/Authoritative/Player.prefab
@@ -101,7 +101,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1594793910609908}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.075}
+  m_LocalPosition: {x: -0.0055, y: -0.0025, z: -0.075}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4532771127299994}
@@ -476,7 +476,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1889680010243874}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0055, y: -0.0025, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4323650176391204}

--- a/workers/unity/Assets/Fps/Resources/Prefabs/UnityClient/Authoritative/Player.prefab
+++ b/workers/unity/Assets/Fps/Resources/Prefabs/UnityClient/Authoritative/Player.prefab
@@ -101,7 +101,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1594793910609908}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.075}
+  m_LocalPosition: {x: -0.0055, y: -0.0025, z: -0.075}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4532771127299994}
@@ -471,7 +471,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1889680010243874}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0055, y: -0.0025, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4323650176391204}


### PR DESCRIPTION
The bug: After death, the gun would be mis-aligned when aiming down scope.

The issue: Some fine tuning adjustments were made to the camera object on the player prefab, but the camera transform gets reset to zero on respawn, nullifying the adjustments.

The fix: Moved the camera adjustments to the parent CameraSocket object to which the camera is attached. Updated both `UnityClient` and `MobileClient` Authoratitive player prefabs.

Tested locally in editor on desktop with sim players.