### PR TITLE
Clean up worker connectors + make map building deferred over frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@
 - The four middle tiles of the world are no longer forced to be of certain tile type.
 - World tile prefabs improved.
 	- Now make use of nested prefabs.
-	- Completely new set of default tiles used to populate the world
-- Updated the build configuration asset
+	- Completely new set of default tiles used to populate the world.
+- Updated the build configuration asset.
 - Reduced the amount of health that gets regenerated. 
+- Map generation is now asynchronous.
 
 ### Fixed
 

--- a/default_launch.json
+++ b/default_launch.json
@@ -95,10 +95,7 @@
       ],      
       "permissions": [{
           "all": {}
-      }],
-      "load_balancing": {
-        "singleton_worker": {}
-      }
+      }]
     },
     {
       "worker_type": "iOSClient",
@@ -110,10 +107,7 @@
       ],      
       "permissions": [{
           "all": {}
-      }],
-      "load_balancing": {
-        "singleton_worker": {}
-      }
+      }]
     }
   ]
 }

--- a/workers/unity/Assets/Fps/Scripts/Config/MapBuilder.cs
+++ b/workers/unity/Assets/Fps/Scripts/Config/MapBuilder.cs
@@ -481,7 +481,7 @@ namespace Fps
                 yield break;
             }
 
-            var levelInstance = worker.LevelInstance;
+            var levelInstance = worker.LevelInstance = new GameObject();
             levelInstance.name = $"FPS-Level_{worldLayerCount}({workerType})";
             levelInstance.transform.position = workerTransform.position;
             levelInstance.transform.rotation = workerTransform.rotation;

--- a/workers/unity/Assets/Fps/Scripts/Editor/MapBuilderVisualisationWindow.cs
+++ b/workers/unity/Assets/Fps/Scripts/Editor/MapBuilderVisualisationWindow.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Improbable.Gdk.Core;
 using UnityEditor;
 using UnityEngine;
@@ -14,7 +15,7 @@ namespace Fps.Editor
         private MapBuilder mapBuilder;
         private MapBuilderSettings mapBuilderSettings;
 
-        private GameObject TileTypeVolumesPrefab;
+        private GameObject tileTypeVolumesPrefab;
 
         private const string MapBuilderMenuItem = "SpatialOS/Map Builder";
         private const int MapBuilderMenuPriority = 52;
@@ -75,7 +76,7 @@ namespace Fps.Editor
                         ? null
                         : Instantiate(mapBuilderSettings.WorldTileVolumes);
 
-                    mapBuilder.CleanAndBuild(layerCount, seed);
+                    UnwindCoroutine(mapBuilder.CleanAndBuild(layerCount, seed));
 
                     if (volumesPrefab != null)
                     {
@@ -108,6 +109,17 @@ namespace Fps.Editor
         private int GetTotalTilesFromLayers(int layers)
         {
             return Mathf.RoundToInt(Mathf.Pow(layers * 2, 2));
+        }
+
+        private void UnwindCoroutine(IEnumerator enumerator)
+        {
+            while (enumerator.MoveNext())
+            {
+                if (enumerator.Current is IEnumerator nestedEnumerator)
+                {
+                    UnwindCoroutine(nestedEnumerator);
+                }
+            }
         }
     }
 }

--- a/workers/unity/Assets/Fps/Scripts/Editor/MapBuilderVisualisationWindow.cs
+++ b/workers/unity/Assets/Fps/Scripts/Editor/MapBuilderVisualisationWindow.cs
@@ -15,8 +15,6 @@ namespace Fps.Editor
         private MapBuilder mapBuilder;
         private MapBuilderSettings mapBuilderSettings;
 
-        private GameObject tileTypeVolumesPrefab;
-
         private const string MapBuilderMenuItem = "SpatialOS/Map Builder";
         private const int MapBuilderMenuPriority = 52;
 

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/WorldTiles/TileEnabler.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/WorldTiles/TileEnabler.cs
@@ -5,7 +5,6 @@ namespace Fps
     public class TileEnabler : MonoBehaviour
     {
         public Transform PlayerTransform;
-        public bool IsClient;
 
         private bool renderersEnabled = true;
 
@@ -18,9 +17,9 @@ namespace Fps
 
         private MeshRenderer meshRenderer;
 
-        private void Start()
+        public void Initialize(bool isClient)
         {
-            if (!IsClient)
+            if (!isClient)
             {
                 Destroy(this);
                 return;

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/WorldTiles/TileTypeCollection.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/WorldTiles/TileTypeCollection.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using Random = System.Random;
 
 namespace Fps
 {
@@ -10,12 +11,12 @@ namespace Fps
         [SerializeField] private Color displayColor = Color.blue;
         public Color DisplayColor => displayColor;
 
-        public GameObject GetRandomTile()
+        public GameObject GetRandomTile(Random random)
         {
-            var rand = Random.value;
+            var rand = random.NextDouble();
             if (chanceOfEmptyTile == 0f || rand > chanceOfEmptyTile)
             {
-                return tiles[Random.Range(0, tiles.Length)];
+                return tiles[random.Next(0, tiles.Length)];
             }
 
             return null;

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/WorldTiles/TileTypeVolume.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/WorldTiles/TileTypeVolume.cs
@@ -29,10 +29,5 @@ namespace Fps
             Gizmos.matrix = Matrix4x4.TRS(transform.position, transform.rotation, transform.lossyScale);
             Gizmos.DrawCube(boxCollider.center, boxCollider.size);
         }
-
-        public GameObject GetRandomTile()
-        {
-            return TypeCollection?.GetRandomTile();
-        }
     }
 }

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/AndroidWorkerConnector.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/AndroidWorkerConnector.cs
@@ -1,66 +1,26 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Improbable.Gdk.Core;
-using Improbable.Gdk.GameObjectCreation;
-using Improbable.Gdk.Subscriptions;
-using Improbable.Gdk.Mobile;
-using Improbable.Gdk.PlayerLifecycle;
-using Improbable.Worker.CInterop;
 using UnityEngine;
 #if UNITY_ANDROID
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Mobile;
 using Improbable.Gdk.Mobile.Android;
 #endif
 
 namespace Fps
 {
-    [RequireComponent(typeof(ConnectionController))]
-    public class AndroidWorkerConnector : MobileWorkerConnector, ITileProvider
+    public class AndroidWorkerConnector : MobileWorkerConnectorBase, ITileProvider
     {
-        private const string AuthPlayer = "Prefabs/MobileClient/Authoritative/Player";
-        private const string NonAuthPlayer = "Prefabs/MobileClient/NonAuthoritative/Player";
-
-        private const string Small = "small";
-        private const string Large = "large";
-
-        public bool ShouldConnectLocally;
-        public int TargetFrameRate = 60;
-
-        [SerializeField] private MapBuilderSettings MapBuilderSettings;
-
-        private GameObject levelInstance;
-
-        private List<TileEnabler> levelTiles = new List<TileEnabler>();
-        public List<TileEnabler> LevelTiles => levelTiles;
-
-        private ConnectionController connectionController;
-
-        public string IpAddress { get; set; }
-
-        private void Awake()
-        {
-            connectionController = GetComponent<ConnectionController>();
-
-            if (!ShouldConnectLocally)
-            {
-                var textAsset = Resources.Load<TextAsset>("DevAuthToken");
-                if (textAsset != null)
-                {
-                    DevelopmentAuthToken = textAsset.text.Trim();
-                }
-                else
-                {
-                    Debug.LogWarning("Unable to find DevAuthToken.txt in the Resources folder.");
-                }
-            }
-        }
-
-        protected virtual async void Start()
+        protected override async void Start()
         {
             Application.targetFrameRate = TargetFrameRate;
 #if UNITY_ANDROID && !UNITY_EDITOR
             UseIpAddressFromArguments();
 #endif
             await AttemptConnect();
+        }
+
+        protected override string GetWorkerType()
+        {
+            return WorkerUtils.AndroidClient;
         }
 
 #if UNITY_ANDROID && !UNITY_EDITOR
@@ -101,77 +61,6 @@ namespace Fps
             throw new System.PlatformNotSupportedException(
                 $"{nameof(AndroidWorkerConnector)} can only be used for the Android platform. Please check your build settings.");
 #endif
-        }
-
-        private async Task AttemptConnect()
-        {
-            await Connect(WorkerUtils.AndroidClient, new ForwardingDispatcher()).ConfigureAwait(false);
-        }
-
-        protected override string SelectDeploymentName(DeploymentList deployments)
-        {
-            // This could be replaced with a splash screen asking to select a deployment or some other user-defined logic.
-            return deployments.Deployments[0].DeploymentName;
-        }
-
-        protected override ConnectionService GetConnectionService()
-        {
-            if (ShouldConnectLocally)
-            {
-                return ConnectionService.Receptionist;
-            }
-
-            return ConnectionService.AlphaLocator;
-        }
-
-        protected override void HandleWorkerConnectionEstablished()
-        {
-            var world = Worker.World;
-
-            // Only take the Heartbeat from the PlayerLifecycleConfig Client Systems.
-            world.GetOrCreateManager<HandlePlayerHeartbeatRequestSystem>();
-
-            var fallback = new GameObjectCreatorFromMetadata(Worker.WorkerType, Worker.Origin, Worker.LogDispatcher);
-
-            // Set the Worker gameObject to the ClientWorker so it can access PlayerCreater reader/writers
-            GameObjectCreationHelper.EnableStandardGameObjectCreation(
-                world,
-                new AdvancedEntityPipeline(Worker, AuthPlayer, NonAuthPlayer, fallback),
-                gameObject);
-
-            LoadWorld();
-        }
-
-        protected override void HandleWorkerConnectionFailure(string errorMessage)
-        {
-            connectionController.OnFailedToConnect();
-        }
-
-        public override void Dispose()
-        {
-            if (levelInstance != null)
-            {
-                Destroy(levelInstance);
-            }
-
-            base.Dispose();
-        }
-
-        // Get the world size from the config, and use it to load the appropriate level.
-        protected virtual void LoadWorld()
-        {
-            levelInstance = MapBuilder.GenerateMap(
-                MapBuilderSettings,
-                transform,
-                Worker.Connection,
-                Worker.WorkerType,
-                Worker.LogDispatcher);
-
-            levelInstance.GetComponentsInChildren<TileEnabler>(true, levelTiles);
-            foreach (var tileEnabler in levelTiles)
-            {
-                tileEnabler.IsClient = true;
-            }
         }
     }
 }

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/ClientWorkerConnector.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/ClientWorkerConnector.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Improbable.Gdk.GameObjectCreation;
@@ -22,20 +23,9 @@ namespace Fps
             connectionController = GetComponent<ConnectionController>();
         }
 
-        protected override async void Start()
-        {
-            Application.targetFrameRate = 60;
-            await AttemptConnect();
-        }
-
         protected override string GetWorkerType()
         {
             return WorkerUtils.UnityClient;
-        }
-
-        public async void Reconnect()
-        {
-            await AttemptConnect();
         }
 
         protected override void HandleWorkerConnectionEstablished()
@@ -61,15 +51,17 @@ namespace Fps
             connectionController.OnFailedToConnect();
         }
 
-        protected override void LoadWorld()
+        protected override IEnumerator LoadWorld()
         {
-            base.LoadWorld();
+            yield return base.LoadWorld();
 
-            levelInstance.GetComponentsInChildren<TileEnabler>(true, levelTiles);
+            LevelInstance.GetComponentsInChildren<TileEnabler>(true, levelTiles);
             foreach (var tileEnabler in levelTiles)
             {
                 tileEnabler.IsClient = true;
             }
+
+            connectionController.OnReadyToSpawn();
         }
     }
 }

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/ClientWorkerConnector.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/ClientWorkerConnector.cs
@@ -58,7 +58,7 @@ namespace Fps
             LevelInstance.GetComponentsInChildren<TileEnabler>(true, levelTiles);
             foreach (var tileEnabler in levelTiles)
             {
-                tileEnabler.IsClient = true;
+                tileEnabler.Initialize(true);
             }
 
             connectionController.OnReadyToSpawn();

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/ConnectionController.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/ConnectionController.cs
@@ -16,6 +16,9 @@ namespace Fps
         private Animator connectButton;
         private WorkerConnector clientWorkerConnector;
 
+        private bool isReadyToSpawn;
+        private bool wantsSpawn;
+
         private void Start()
         {
             clientWorkerConnector = gameObject.GetComponent<WorkerConnector>();
@@ -57,6 +60,12 @@ namespace Fps
                     connectButton.SetTrigger("Ready");
                 }
             }
+
+            if (wantsSpawn && isReadyToSpawn)
+            {
+                SpawnPlayer();
+                wantsSpawn = false;
+            }
         }
 
         public void OnFailedToConnect()
@@ -65,6 +74,10 @@ namespace Fps
             connectButton.SetTrigger("FailedToConnect");
         }
 
+        public void OnReadyToSpawn()
+        {
+            isReadyToSpawn = true;
+        }
 
         private void SpawnPlayer()
         {
@@ -77,12 +90,12 @@ namespace Fps
             if (connectButton.GetCurrentAnimatorStateInfo(0).IsName("ReadyState"))
             {
                 connectButton.SetTrigger("Connecting");
-                SpawnPlayer();
+                wantsSpawn = true;
             }
             else if (connectButton.GetCurrentAnimatorStateInfo(0).IsName("FailedToSpawn"))
             {
                 connectButton.SetTrigger("Retry");
-                SpawnPlayer();
+                wantsSpawn = true;
             }
             else if (connectButton.GetCurrentAnimatorStateInfo(0).IsName("FailedToConnect")
                 || connectButton.GetCurrentAnimatorStateInfo(0).IsName("WorkerDisconnected"))

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/GameLogicWorkerConnector.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/GameLogicWorkerConnector.cs
@@ -40,6 +40,12 @@ namespace Fps
         protected override IEnumerator LoadWorld()
         {
             yield return base.LoadWorld();
+            
+            var levelTiles = LevelInstance.GetComponentsInChildren<TileEnabler>(true);
+            foreach (var tileEnabler in levelTiles)
+            {
+                tileEnabler.Initialize(false);
+            }
 
             if (DisableRenderers)
             {

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/GameLogicWorkerConnector.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/GameLogicWorkerConnector.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using Improbable.Gdk.GameObjectCreation;
 using Improbable.Gdk.Subscriptions;
@@ -10,12 +11,6 @@ namespace Fps
     public class GameLogicWorkerConnector : WorkerConnectorBase
     {
         public bool DisableRenderers = true;
-
-        protected override async void Start()
-        {
-            Application.targetFrameRate = 60;
-            await AttemptConnect();
-        }
 
         protected override string GetWorkerType()
         {
@@ -42,13 +37,13 @@ namespace Fps
             base.HandleWorkerConnectionEstablished();
         }
 
-        protected override void LoadWorld()
+        protected override IEnumerator LoadWorld()
         {
-            base.LoadWorld();
+            yield return base.LoadWorld();
 
             if (DisableRenderers)
             {
-                foreach (var childRenderer in levelInstance.GetComponentsInChildren<Renderer>())
+                foreach (var childRenderer in LevelInstance.GetComponentsInChildren<Renderer>())
                 {
                     childRenderer.enabled = false;
                 }

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/MobileWorkerConnectorBase.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/MobileWorkerConnectorBase.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.GameObjectCreation;
+using Improbable.Gdk.PlayerLifecycle;
+using Improbable.Worker.CInterop;
+using Improbable.Worker.CInterop.Alpha;
+using UnityEngine;
+
+namespace Fps
+{
+    [RequireComponent(typeof(ConnectionController))]
+    public abstract class MobileWorkerConnectorBase : WorkerConnectorBase
+    {
+        private const string AuthPlayer = "Prefabs/MobileClient/Authoritative/Player";
+        private const string NonAuthPlayer = "Prefabs/MobileClient/NonAuthoritative/Player";
+
+        public List<TileEnabler> LevelTiles => levelTiles;
+
+        protected string IpAddress;
+
+        [SerializeField] private bool shouldConnectLocally;
+
+        private ConnectionController connectionController;
+        private List<TileEnabler> levelTiles = new List<TileEnabler>();
+
+        private void Awake()
+        {
+            connectionController = GetComponent<ConnectionController>();
+
+            if (!shouldConnectLocally)
+            {
+                LoadDevAuthToken();
+            }
+        }
+
+        #region Connection Configuration
+
+        protected abstract string GetHostIp();
+
+        protected override ConnectionParameters GetConnectionParameters(string workerType, ConnectionService service)
+        {
+            return new ConnectionParameters
+            {
+                WorkerType = workerType,
+                Network =
+                {
+                    ConnectionType = NetworkConnectionType.Kcp,
+                    UseExternalIp = true,
+                    Kcp = new KcpNetworkParameters
+                    {
+                        Heartbeat = new HeartbeatParameters()
+                        {
+                            IntervalMillis = 5000,
+                            TimeoutMillis = 10000
+                        }
+                    }
+                },
+                EnableProtocolLoggingAtStartup = false,
+                DefaultComponentVtable = new ComponentVtable(),
+            };
+        }
+
+        protected override ReceptionistConfig GetReceptionistConfig(string workerType)
+        {
+            return new ReceptionistConfig
+            {
+                ReceptionistHost = GetHostIp(),
+                ReceptionistPort = RuntimeConfigDefaults.ReceptionistPort,
+                WorkerId = CreateNewWorkerId(workerType)
+            };
+        }
+
+        protected override LocatorConfig GetLocatorConfig()
+        {
+            throw new NotImplementedException("The locator flow is currently not available for mobile workers.");
+        }
+
+        protected override AlphaLocatorConfig GetAlphaLocatorConfig(string workerType)
+        {
+            var pit = GetDevelopmentPlayerIdentityToken(DevelopmentAuthToken, GetPlayerId(), GetDisplayName());
+            var loginTokenDetails = GetDevelopmentLoginTokens(workerType, pit);
+            var loginToken = SelectLoginToken(loginTokenDetails);
+
+            return new AlphaLocatorConfig
+            {
+                LocatorHost = RuntimeConfigDefaults.LocatorHost,
+                LocatorParameters = new Improbable.Worker.CInterop.Alpha.LocatorParameters
+                {
+                    PlayerIdentity = new PlayerIdentityCredentials
+                    {
+                        PlayerIdentityToken = pit,
+                        LoginToken = loginToken,
+                    },
+                    UseInsecureConnection = false,
+                }
+            };
+        }
+
+        protected override ConnectionService GetConnectionService()
+        {
+            if (shouldConnectLocally)
+            {
+                return ConnectionService.Receptionist;
+            }
+
+            return ConnectionService.AlphaLocator;
+        }
+
+        private void LoadDevAuthToken()
+        {
+            var textAsset = Resources.Load<TextAsset>("DevAuthToken");
+            if (textAsset != null)
+            {
+                DevelopmentAuthToken = textAsset.text.Trim();
+            }
+            else
+            {
+                Debug.LogWarning("Unable to find DevAuthToken.txt in the Resources folder.");
+            }
+        }
+
+        #endregion
+
+        protected override void HandleWorkerConnectionEstablished()
+        {
+            var world = Worker.World;
+
+            // Only take the Heartbeat from the PlayerLifecycleConfig Client Systems.
+            world.GetOrCreateManager<HandlePlayerHeartbeatRequestSystem>();
+
+            var fallback = new GameObjectCreatorFromMetadata(Worker.WorkerType, Worker.Origin, Worker.LogDispatcher);
+
+            // Set the Worker gameObject to the ClientWorker so it can access PlayerCreater reader/writers
+            GameObjectCreationHelper.EnableStandardGameObjectCreation(
+                world,
+                new AdvancedEntityPipeline(Worker, AuthPlayer, NonAuthPlayer, fallback),
+                gameObject);
+
+            StartCoroutine(LoadWorld());
+        }
+
+        protected override void HandleWorkerConnectionFailure(string errorMessage)
+        {
+            connectionController.OnFailedToConnect();
+        }
+
+        protected override IEnumerator LoadWorld()
+        {
+            yield return base.LoadWorld();
+
+            LevelInstance.GetComponentsInChildren<TileEnabler>(true, levelTiles);
+            foreach (var tileEnabler in levelTiles)
+            {
+                tileEnabler.IsClient = true;
+            }
+
+            connectionController.OnReadyToSpawn();
+        }
+
+        public override void Dispose()
+        {
+            if (LevelInstance != null)
+            {
+                Destroy(LevelInstance);
+            }
+
+            base.Dispose();
+        }
+    }
+}

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/MobileWorkerConnectorBase.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/MobileWorkerConnectorBase.cs
@@ -153,7 +153,7 @@ namespace Fps
             LevelInstance.GetComponentsInChildren<TileEnabler>(true, levelTiles);
             foreach (var tileEnabler in levelTiles)
             {
-                tileEnabler.IsClient = true;
+                tileEnabler.Initialize(true);
             }
 
             connectionController.OnReadyToSpawn();

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/MobileWorkerConnectorBase.cs.meta
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/MobileWorkerConnectorBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: de94081b87624120a12631f750beedd8
+timeCreated: 1552576261

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/SimulatedPlayerCoordinatorWorkerConnector.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/SimulatedPlayerCoordinatorWorkerConnector.cs
@@ -85,7 +85,7 @@ public class SimulatedPlayerCoordinatorWorkerConnector : WorkerConnectorBase
                     var simulatedPlayer = Instantiate(SimulatedPlayerWorkerConnector, transform.position, transform.rotation);
                     var task = simulatedPlayer.GetComponent<SimulatedPlayerWorkerConnector>()
                         .ConnectSimulatedPlayer(Worker.LogDispatcher, SimulatedPlayerDevAuthTokenId, SimulatedPlayerTargetDeployment);
-                    task.Wait();
+                    yield return new WaitUntil(() => task.IsCompleted);
                     simulatedPlayerConnectors.Add(simulatedPlayer);
                 }
 

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/WorkerConnectorBase.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/WorkerConnectorBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Threading.Tasks;
 using Improbable.Gdk.Core;
@@ -12,7 +13,7 @@ namespace Fps
 
         [SerializeField] protected MapBuilderSettings MapBuilderSettings;
 
-        public GameObject LevelInstance;
+        [NonSerialized] internal GameObject LevelInstance;
 
         protected abstract string GetWorkerType();
 

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/WorkerConnectorBase.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/WorkerConnectorBase.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Threading.Tasks;
 using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
@@ -11,7 +12,7 @@ namespace Fps
 
         [SerializeField] protected MapBuilderSettings MapBuilderSettings;
 
-        protected GameObject levelInstance;
+        public GameObject LevelInstance;
 
         protected abstract string GetWorkerType();
 
@@ -34,29 +35,30 @@ namespace Fps
 
         protected override void HandleWorkerConnectionEstablished()
         {
-            LoadWorld();
+            StartCoroutine(LoadWorld());
         }
 
         public override void Dispose()
         {
-            if (levelInstance != null)
+            if (LevelInstance != null)
             {
-                Destroy(levelInstance);
-                levelInstance = null;
+                Destroy(LevelInstance);
+                LevelInstance = null;
             }
 
             base.Dispose();
         }
 
         // Get the world size from the config, and use it to generate the correct-sized level
-        protected virtual void LoadWorld()
+        protected virtual IEnumerator LoadWorld()
         {
-            levelInstance = MapBuilder.GenerateMap(
+            yield return MapBuilder.GenerateMap(
                 MapBuilderSettings,
                 transform,
                 Worker.Connection,
                 Worker.WorkerType,
-                Worker.LogDispatcher);
+                Worker.LogDispatcher,
+                this);
         }
     }
 }

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/iOSWorkerConnector.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/iOSWorkerConnector.cs
@@ -1,12 +1,4 @@
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using Improbable.Gdk.Core;
-using Improbable.Gdk.GameObjectCreation;
-using Improbable.Gdk.Subscriptions;
-using Improbable.Gdk.Mobile;
-using Improbable.Gdk.PlayerLifecycle;
-using Improbable.Worker.CInterop;
 using UnityEngine;
 
 #if UNITY_IOS
@@ -15,62 +7,26 @@ using Improbable.Gdk.Mobile.iOS;
 
 namespace Fps
 {
-    [RequireComponent(typeof(ConnectionController))]
-    public class iOSWorkerConnector : MobileWorkerConnector, ITileProvider
+    public class iOSWorkerConnector : MobileWorkerConnectorBase, ITileProvider
     {
-        private const string AuthPlayer = "Prefabs/MobileClient/Authoritative/Player";
-        private const string NonAuthPlayer = "Prefabs/MobileClient/NonAuthoritative/Player";
+        [SerializeField] private string forcedIpAddress;
 
-        public string forcedIpAddress;
+        protected override async void Start()
+        {
+            Application.targetFrameRate = TargetFrameRate;
+            IpAddress = forcedIpAddress;
 
-        public bool ShouldConnectLocally;
-        public int TargetFrameRate = 60;
-
-        [SerializeField] private MapBuilderSettings MapBuilderSettings;
-
-        private GameObject levelInstance;
-
-        private List<TileEnabler> levelTiles = new List<TileEnabler>();
-        public List<TileEnabler> LevelTiles => levelTiles;
-
-        private ConnectionController connectionController;
-
-        public string IpAddress { get; set; }
+            await AttemptConnect();
+        }
 
         private void OnValidate()
         {
             forcedIpAddress = Regex.Replace(forcedIpAddress, "[^0-9.]", "");
         }
 
-        public async void TryConnect()
+        protected override string GetWorkerType()
         {
-            await Connect(WorkerUtils.iOSClient, new ForwardingDispatcher()).ConfigureAwait(false);
-        }
-
-        private void Awake()
-        {
-            connectionController = GetComponent<ConnectionController>();
-
-            if (!ShouldConnectLocally)
-            {
-                var textAsset = Resources.Load<TextAsset>("DevAuthToken");
-                if (textAsset != null)
-                {
-                    DevelopmentAuthToken = textAsset.text.Trim();
-                }
-                else
-                {
-                    Debug.LogWarning("Unable to find DevAuthToken.txt in the Resources folder.");
-                }
-            }
-        }
-
-        protected virtual async void Start()
-        {
-            Application.targetFrameRate = TargetFrameRate;
-            IpAddress = forcedIpAddress;
-
-            await AttemptConnect();
+            return WorkerUtils.iOSClient;
         }
 
         protected override string GetHostIp()
@@ -86,82 +42,6 @@ namespace Fps
             throw new System.PlatformNotSupportedException(
                 $"{nameof(iOSWorkerConnector)} can only be used for the iOS platform. Please check your build settings.");
 #endif
-        }
-
-        public async void Reconnect()
-        {
-            await AttemptConnect();
-        }
-
-        protected async Task AttemptConnect()
-        {
-            await Connect(WorkerUtils.iOSClient, new ForwardingDispatcher()).ConfigureAwait(false);
-        }
-
-        protected override string SelectDeploymentName(DeploymentList deployments)
-        {
-            // This could be replaced with a splash screen asking to select a deployment or some other user-defined logic.
-            return deployments.Deployments[0].DeploymentName;
-        }
-
-        protected override ConnectionService GetConnectionService()
-        {
-            if (ShouldConnectLocally)
-            {
-                return ConnectionService.Receptionist;
-            }
-
-            return ConnectionService.AlphaLocator;
-        }
-
-        protected override void HandleWorkerConnectionEstablished()
-        {
-            var world = Worker.World;
-
-            // Only take the Heartbeat from the PlayerLifecycleConfig Client Systems.
-            world.GetOrCreateManager<HandlePlayerHeartbeatRequestSystem>();
-
-            var fallback = new GameObjectCreatorFromMetadata(Worker.WorkerType, Worker.Origin, Worker.LogDispatcher);
-
-            // Set the Worker gameObject to the ClientWorker so it can access PlayerCreater reader/writers
-            GameObjectCreationHelper.EnableStandardGameObjectCreation(
-                world,
-                new AdvancedEntityPipeline(Worker, AuthPlayer, NonAuthPlayer, fallback),
-                gameObject);
-
-            LoadWorld();
-        }
-
-        protected override void HandleWorkerConnectionFailure(string errorMessage)
-        {
-            connectionController.OnFailedToConnect();
-        }
-
-        public override void Dispose()
-        {
-            if (levelInstance != null)
-            {
-                Destroy(levelInstance);
-            }
-
-            base.Dispose();
-        }
-
-        // Get the world size from the config, and use it to load the appropriate level.
-        protected virtual void LoadWorld()
-        {
-            levelInstance = MapBuilder.GenerateMap(
-                MapBuilderSettings,
-                transform,
-                Worker.Connection,
-                Worker.WorkerType,
-                Worker.LogDispatcher);
-
-            levelInstance.GetComponentsInChildren<TileEnabler>(true, levelTiles);
-            foreach (var tileEnabler in levelTiles)
-            {
-                tileEnabler.IsClient = true;
-            }
         }
     }
 }


### PR DESCRIPTION
#### Description
This PR has a few changes: 
- Drive-by cleanup of some old worker configurations.
- Made map building deferred over multiple frames instead of blocking. This stops the `SimulatedPlayerCoordinator` workers from falling over at startup and allow them to maintain a reasonable FPS such that they can respond to pings.
	- Note that this does have consequences on other parts of the codebase (i.e. - cannot spawn until map is built). There is still an unresolved question of what happens if a UnityGameLogic worker goes down and starts to checkout existing players _before_ the map is built, but this is an edge case (and I expect that since we are client side auth, it will _probably_ be okay). 
- Cleaning up the structure of the worker connectors (still work to do, but they are more aligned). We now have the following class structure:
```
WorkerConnectorBase
  - ClientWorkerConnector
  - GameLogicWorkerConnector
  - SimulatedPlayerCoordinatorConnector
  - MobileWorkerConnectorBase
    - AndroidWorkerConnector
	- iOSWorkerConnector 
```

Ultimately the client and mobile ones can probably be unified as there is a lot in common with them. Equally if the worker abstraction and the connectors are likely to change in the near-ish future (which it looks like they are) it may not be worth going that far.

#### Tests
- [x] Tested local deployment
- [ ] Test Android
- [ ] Test iOS
- [ ] Test cloud deployment
#### Documentation
Needs a changelog.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
