### PR TITLE
Deployment launcher - underlying dotnet processes get killed if you close Unity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Updated the `ConnectionController` and `ClientWorkerConnector` to make full use of the updated Player Lifecycle Feature Module.
 
+### Fixed
+
+- Fixed a bug where closing Unity while the `DeploymentLauncher` was running would orphan the underlying processes.
+
 ### Internal
 
 - Fixed package dependencies.

--- a/gdk.pinned
+++ b/gdk.pinned
@@ -1,1 +1,1 @@
-9ffeb3a183dcfe5407172d82eac79fdd7ec1b5e3
+7d8864b7

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncher.cs
@@ -387,32 +387,17 @@ namespace Improbable.Gdk.DeploymentManager
 
             private static bool ValidateProjectName(string projectName)
             {
-                if (string.IsNullOrEmpty(projectName))
-                {
-                    return false;
-                }
-
-                return Regex.Match(projectName, "^[a-z0-9_]{3,32}$").Success;
+                return !string.IsNullOrEmpty(projectName) && Regex.Match(projectName, "^[a-z0-9_]{3,32}$").Success;
             }
 
             private static bool ValidateAssemblyName(string assemblyName)
             {
-                if (string.IsNullOrEmpty(assemblyName))
-                {
-                    return false;
-                }
-
-                return Regex.Match(assemblyName, "^[a-zA-Z0-9_.-]{5,64}$").Success;
+                return !string.IsNullOrEmpty(assemblyName) && Regex.Match(assemblyName, "^[a-zA-Z0-9_.-]{5,64}$").Success;
             }
 
             private static bool ValidateDeploymentName(string deploymentName)
             {
-                if (string.IsNullOrEmpty(deploymentName))
-                {
-                    return false;
-                }
-
-                return Regex.Match(deploymentName, "^[a-z0-9_]{2,32}$").Success;
+                return !string.IsNullOrEmpty(deploymentName) && Regex.Match(deploymentName, "^[a-z0-9_]{2,32}$").Success;
             }
 
             private void DrawSpinner(float value, Rect rect)

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentTasks.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentTasks.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Improbable.Gdk.Tools;
+using UnityEditor;
+using UnityEngine;
+
+namespace Improbable.Gdk.DeploymentManager
+{
+    internal static class DeploymentTasks
+    {
+        private static readonly string DotNetProjectPath =
+            Path.GetFullPath(Path.Combine(Tools.Common.GetPackagePath("com.improbable.gdk.deploymentlauncher"),
+                ".DeploymentLauncher/DeploymentLauncher.csproj"));
+
+        public class WrappedTask<TResult> : IDisposable
+        {
+            public Task<TResult> Task;
+            public CancellationTokenSource CancelSource;
+
+            public void Dispose()
+            {
+                Task?.Dispose();
+                CancelSource?.Dispose();
+            }
+        }
+
+        public static WrappedTask<bool> TriggerUploadAssemblyAsync(string[] arguments, Action onSuccess,
+            Action onFailure)
+        {
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+            var projectRootPath = Path.Combine(Application.dataPath, "../../../");
+
+            var task = Task.Run(async () =>
+            {
+                if (!Tools.Common.CheckDependencies())
+                {
+                    return false;
+                }
+
+                var processResult = await RedirectedProcess.Command(Tools.Common.SpatialBinary).WithArgs(arguments)
+                    .RedirectOutputOptions(OutputRedirectBehaviour.RedirectStdOut |
+                        OutputRedirectBehaviour.RedirectStdErr | OutputRedirectBehaviour.ProcessSpatialOutput)
+                    .InDirectory(projectRootPath)
+                    .RunAsync(token);
+
+                if (processResult.ExitCode == 0)
+                {
+                    onSuccess();
+                    return true;
+                }
+
+                onFailure();
+                return false;
+            });
+
+            return new WrappedTask<bool>
+            {
+                Task = task,
+                CancelSource = source
+            };
+        }
+
+        public static WrappedTask<bool> TriggerLaunchDeploymentAsync(List<string> arguments, Action onSuccess)
+        {
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+            var dotNetWorkingDirectory = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+
+            EditorApplication.LockReloadAssemblies();
+
+            var task = Task.Run(async () =>
+                {
+                    if (!Tools.Common.CheckDependencies())
+                    {
+                        return false;
+                    }
+
+                    var processResult = await RedirectedProcess.Command(Tools.Common.DotNetBinary)
+                        .WithArgs(ConstructArguments(arguments))
+                        .RedirectOutputOptions(OutputRedirectBehaviour.RedirectStdOut |
+                            OutputRedirectBehaviour.RedirectStdErr)
+                        .InDirectory(dotNetWorkingDirectory)
+                        .RunAsync(token);
+
+                    if (processResult.ExitCode == 0)
+                    {
+                        onSuccess();
+                    }
+
+                    return processResult.ExitCode != 0;
+                }
+            );
+
+            return new WrappedTask<bool>
+            {
+                Task = task,
+                CancelSource = source
+            };
+        }
+
+        public static WrappedTask<bool> TriggerStopDeploymentAsync(List<string> arguments, Action onSuccess, Action<RedirectedProcessResult> onFailure)
+        {
+            if (!Tools.Common.CheckDependencies())
+            {
+                return null;
+            }
+
+            var dotNetWorkingDirectory = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+            var task = Task.Run(async () =>
+            {
+                var processResult = await RunDeploymentLauncherHelperAsync(token, dotNetWorkingDirectory, arguments, true);
+                if (processResult.ExitCode != 0)
+                {
+                    onFailure(processResult);
+                    return false;
+                }
+
+                onSuccess();
+                return true;
+            });
+
+            return new WrappedTask<bool>
+            {
+                Task = task,
+                CancelSource = source
+            };
+        }
+
+        public static WrappedTask<List<DeploymentManager.DeploymentInfo>> TriggerListDeploymentsAsync(List<string> args,
+            bool redirectStdout = false)
+        {
+            if (!Tools.Common.CheckDependencies())
+            {
+                return null;
+            }
+
+            var dotNetWorkingDirectory = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+            var task = Task.Run(async () =>
+            {
+                var processResult = await RunDeploymentLauncherHelperAsync(token, dotNetWorkingDirectory, args, redirectStdout);
+                if (processResult.ExitCode != 0)
+                {
+                    return null;
+                }
+
+                // Get deployments from output.
+                var deploymentList = new List<DeploymentManager.DeploymentInfo>();
+                foreach (var line in processResult.Stdout)
+                {
+                    var tokens = line.Split(' ');
+                    if (tokens.Length != 3)
+                    {
+                        continue;
+                    }
+
+                    if (tokens[0] != "<deployment>")
+                    {
+                        continue;
+                    }
+
+                    deploymentList.Add(new DeploymentManager.DeploymentInfo
+                    {
+                        Id = tokens[1],
+                        Name = tokens[2]
+                    });
+                }
+
+                deploymentList.Sort((item1, item2) => string.Compare(item1.Name, item2.Name, StringComparison.Ordinal));
+
+                return deploymentList;
+            });
+
+            return new WrappedTask<List<DeploymentManager.DeploymentInfo>>
+            {
+                Task = task,
+                CancelSource = source
+            };
+        }
+
+        public static async Task<RedirectedProcessResult> RunDeploymentLauncherHelperAsync(CancellationToken token,
+            string workingDirectory,
+            List<string> args,
+            bool redirectStdout = false)
+        {
+            var outputOptions = OutputRedirectBehaviour.RedirectStdErr;
+            if (redirectStdout)
+            {
+                outputOptions |= OutputRedirectBehaviour.RedirectStdOut;
+            }
+
+            var processResult = await RedirectedProcess.Command(Tools.Common.DotNetBinary)
+                .WithArgs(ConstructArguments(args))
+                .RedirectOutputOptions(outputOptions)
+                .InDirectory(workingDirectory)
+                .RunAsync(token);
+
+            if (processResult.ExitCode == 0 || token.IsCancellationRequested)
+            {
+                return processResult;
+            }
+
+            // Examine the failure reason.
+            var failureReason = processResult.Stdout.Count > 0 ? processResult.Stdout[0] : "";
+            if (failureReason == "<error:unauthenticated>")
+            {
+                // The reason this task failed is because we are authenticated. Try authenticating.
+                Debug.Log(
+                    "Failed to connect to the SpatialOS platform due to being unauthenticated. Running `spatial auth login` then retrying the last operation...");
+                var spatialAuthLoginResult = await RedirectedProcess.Command(Tools.Common.SpatialBinary)
+                    .WithArgs(new string[] { "auth", "login", "--json_output" })
+                    .RedirectOutputOptions(OutputRedirectBehaviour.RedirectStdErr |
+                        OutputRedirectBehaviour.ProcessSpatialOutput)
+                    .InDirectory(workingDirectory)
+                    .RunAsync(token);
+
+                if (spatialAuthLoginResult.ExitCode == 0)
+                {
+                    // Re-run the task.
+                    processResult = await RedirectedProcess.Command(Tools.Common.DotNetBinary)
+                        .WithArgs(ConstructArguments(args))
+                        .RedirectOutputOptions(OutputRedirectBehaviour.RedirectStdErr)
+                        .InDirectory(workingDirectory)
+                        .RunAsync(token);
+                }
+                else
+                {
+                    Debug.Log("Failed to run `spatial auth login`.");
+                }
+            }
+
+            return processResult;
+        }
+
+        private static string[] ConstructArguments(List<string> args)
+        {
+            var baseArgs = new List<string>
+            {
+                "run",
+                "-p",
+                $"\"{DotNetProjectPath}\"",
+                "--",
+            };
+            baseArgs.AddRange(args.Select(arg => $"\"{arg}\""));
+            return baseArgs.ToArray();
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentTasks.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentTasks.cs
@@ -207,6 +207,7 @@ namespace Improbable.Gdk.DeploymentManager
                 .WithArgs(ConstructArguments(args))
                 .RedirectOutputOptions(outputOptions)
                 .InDirectory(workingDirectory)
+                .WithTimeout(25 * 60) // 25 minute timeout
                 .RunAsync(token);
 
             if (processResult.ExitCode == 0 || token.IsCancellationRequested)
@@ -235,6 +236,7 @@ namespace Improbable.Gdk.DeploymentManager
                         .WithArgs(ConstructArguments(args))
                         .RedirectOutputOptions(OutputRedirectBehaviour.RedirectStdErr)
                         .InDirectory(workingDirectory)
+                        .WithTimeout(60 * 25) // 25 minute timeout
                         .RunAsync(token);
                 }
                 else

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentTasks.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentTasks.cs
@@ -16,6 +16,9 @@ namespace Improbable.Gdk.DeploymentManager
             Path.GetFullPath(Path.Combine(Tools.Common.GetPackagePath("com.improbable.gdk.deploymentlauncher"),
                 ".DeploymentLauncher/DeploymentLauncher.csproj"));
 
+        private static TimeSpan DeploymentLauncherTimeout = new TimeSpan(0, 0, 25, 0);
+
+
         public class WrappedTask<TResult> : IDisposable
         {
             public Task<TResult> Task;
@@ -207,7 +210,7 @@ namespace Improbable.Gdk.DeploymentManager
                 .WithArgs(ConstructArguments(args))
                 .RedirectOutputOptions(outputOptions)
                 .InDirectory(workingDirectory)
-                .WithTimeout(25 * 60) // 25 minute timeout
+                .WithTimeout(DeploymentLauncherTimeout)
                 .RunAsync(token);
 
             if (processResult.ExitCode == 0 || token.IsCancellationRequested)
@@ -236,7 +239,7 @@ namespace Improbable.Gdk.DeploymentManager
                         .WithArgs(ConstructArguments(args))
                         .RedirectOutputOptions(OutputRedirectBehaviour.RedirectStdErr)
                         .InDirectory(workingDirectory)
-                        .WithTimeout(60 * 25) // 25 minute timeout
+                        .WithTimeout(DeploymentLauncherTimeout)
                         .RunAsync(token);
                 }
                 else

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentTasks.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentTasks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ce59a1015a365d4ba9d87f6a36a354b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
Oh man - this was a fun one. If you close Unity while one of the async tasks are running for uploading/launching/refreshing - the underlying `dotnet` process gets killed.

I expect this is _not_ the best way to do this - so if anyone has suggestions please let me know 😬 

The approach essentially is we create a token and pass it to the `RedirectedProcess` command. We register a listener `OnProcessExit` which triggers the cancellation which kills the dotnet process and waits on the task to return (in this case it bubbles up pretty quickly).

**Need to update the pin once https://github.com/spatialos/gdk-for-unity/pull/888 is merged**

#### Tests
Ran things, killed Unity, looked for any orphaned processes, couldn't find any.

#### Documentation
Needs a changelog.

#### Primary reviewers
