### PR TITLE
Deployment launcher refactor part 1 - Pull out configurations + commands

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands.meta
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d65860bdad8ab9448b8e9032c65cebe
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Improbable.Gdk.Tools;
+
+namespace Improbable.Gdk.DeploymentManager.Commands
+{
+    public static class Assembly
+    {
+        public static WrappedTask<bool, AssemblyConfig> UploadAsync(AssemblyConfig config,
+            bool force = false)
+        {
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+            var args = new[]
+            {
+                "cloud",
+                "upload",
+                config.AssemblyName,
+                "--project_name",
+                config.ProjectName,
+                force ? "--json_output --force" : "--json_output"
+            };
+
+            var task = Task.Run(async () =>
+            {
+                var processResult = await RedirectedProcess.Command(Tools.Common.SpatialBinary)
+                    .InDirectory(Tools.Common.SpatialProjectRootDir)
+                    .WithArgs(args)
+                    .RedirectOutputOptions(OutputRedirectBehaviour.RedirectStdOut |
+                        OutputRedirectBehaviour.RedirectStdErr | OutputRedirectBehaviour.ProcessSpatialOutput)
+                    .RunAsync(token);
+
+                return processResult.ExitCode == 0;
+            });
+
+            return new WrappedTask<bool, AssemblyConfig>
+            {
+                Task = task,
+                CancelSource = source,
+                Context = config.DeepCopy()
+            };
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a36f87bde7b1e574098d6e850e28c072
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
@@ -19,7 +19,6 @@ namespace Improbable.Gdk.DeploymentManager.Commands
             var source = new CancellationTokenSource();
             var token = source.Token;
 
-
             // TODO: Allow for no snapshot
             var args = new[]
             {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Improbable.Gdk.Tools;
+
+namespace Improbable.Gdk.DeploymentManager.Commands
+{
+    public static class Deployment
+    {
+        private static string DeploymentLauncherProjectPath = Path.GetFullPath(Path.Combine(
+            Tools.Common.GetPackagePath("com.improbable.gdk.deploymentlauncher"),
+            ".DeploymentLauncher/DeploymentLauncher.csproj"));
+
+        public static WrappedTask<bool, DeploymentConfig> LaunchAsync(DeploymentConfig config)
+        {
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+
+            // TODO: Allow for no snapshot
+            var args = new[]
+            {
+                "create",
+                "--project_name",
+                config.ProjectName,
+                "--assembly_name",
+                config.AssemblyName,
+                "--deployment_name",
+                config.Name,
+                "--launch_json",
+                Path.Combine(Tools.Common.SpatialProjectRootDir, config.LaunchJson),
+                "--snapshot",
+                Path.Combine(Tools.Common.SpatialProjectRootDir, config.SnapshotPath),
+                "--region",
+                config.Region.ToString()
+            };
+
+            var task = RunDeploymentLauncher(args,
+                OutputRedirectBehaviour.RedirectStdErr | OutputRedirectBehaviour.RedirectStdOut, token,
+                result => result.ExitCode == 0);
+
+            task.Start();
+
+            return new WrappedTask<bool, DeploymentConfig>
+            {
+                Task = task,
+                CancelSource = source,
+                Context = config.DeepCopy()
+            };
+        }
+
+        public static WrappedTask<bool, DeploymentInfo> StopAsync(DeploymentInfo info)
+        {
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+            var args = new[]
+            {
+                "stop",
+                "--project_name",
+                info.ProjectName,
+                "--deployment_id",
+                info.Id
+            };
+
+            var task = RunDeploymentLauncher(args,
+                OutputRedirectBehaviour.RedirectStdOut | OutputRedirectBehaviour.RedirectStdErr,
+                token,
+                result => result.ExitCode == 0);
+
+            task.Start();
+
+            return new WrappedTask<bool, DeploymentInfo>
+            {
+                Task = task,
+                CancelSource = source,
+                Context = info
+            };
+        }
+
+        public static WrappedTask<List<DeploymentInfo>, string> ListAsync(string projectName)
+        {
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+            var args = new[]
+            {
+                "list",
+                "--project_name",
+                projectName
+            };
+
+            // TODO: Handle result.
+            var task = RunDeploymentLauncher(args, OutputRedirectBehaviour.RedirectStdErr, token,
+                result => new List<DeploymentInfo>());
+
+            task.Start();
+
+            return new WrappedTask<List<DeploymentInfo>, string>
+            {
+                Task = task,
+                CancelSource = source,
+                Context = projectName
+            };
+        }
+
+        private static async Task<T> RunDeploymentLauncher<T>(string[] programArgs,
+            OutputRedirectBehaviour redirectBehaviour,
+            CancellationToken token,
+            Func<RedirectedProcessResult, T> resultHandler)
+        {
+            var wrappedArgs = new[] { "run", "-p", $"\"{DeploymentLauncherProjectPath}\"" }
+                .Concat(programArgs)
+                .ToArray();
+
+            var processResult = await RedirectedProcess.Command(Tools.Common.DotNetBinary)
+                .InDirectory("") // TODO: Figure out where this should run.
+                .WithArgs(wrappedArgs)
+                .RedirectOutputOptions(redirectBehaviour)
+                .WithTimeout(new TimeSpan(0, 0, 25, 0))
+                .RunAsync(token);
+
+            return resultHandler(processResult);
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fedc06e303a718479a23322b0f891d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/WrappedTask.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/WrappedTask.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Improbable.Gdk.DeploymentManager.Commands
+{
+    public class WrappedTask<TResult, TContext> : IDisposable
+    {
+        public Task<TResult> Task;
+        public CancellationTokenSource CancelSource;
+        public TContext Context;
+
+        public void Dispose()
+        {
+            Task?.Dispose();
+            CancelSource?.Dispose();
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/WrappedTask.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/WrappedTask.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47578587835c1e749a50f2ae3d3c7ba7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
@@ -1,0 +1,110 @@
+using System.Text.RegularExpressions;
+
+namespace Improbable.Gdk.DeploymentManager
+{
+    public class DeploymentConfig
+    {
+        /// <summary>
+        ///     The name of the deployment to launch.
+        /// </summary>
+        public string Name;
+
+        /// <summary>
+        ///     The name of the SpatialOS project to launch in.
+        /// </summary>
+        public string ProjectName;
+
+        /// <summary>
+        ///     The name of the assembly to use in the deployment.
+        /// </summary>
+        public string AssemblyName;
+
+        /// <summary>
+        ///     The relative path from the root of the SpatialOS project to the snapshot.
+        /// </summary>
+        public string SnapshotPath;
+
+        /// <summary>
+        ///     The relative path from the root of the SpatialOS project to the launch json.
+        /// </summary>
+        public string LaunchJson;
+
+        /// <summary>
+        ///     The region to launch the deployment in.
+        /// </summary>
+        public DeploymentRegionCode Region;
+
+        /// <summary>
+        ///     Deep copy this configuration object.
+        /// </summary>
+        /// <returns>A copy of this <see cref="DeploymentConfig"/> object.</returns>
+        internal DeploymentConfig DeepCopy()
+        {
+            return new DeploymentConfig
+            {
+                Name = string.Copy(Name),
+                ProjectName = string.Copy(ProjectName),
+                AssemblyName = string.Copy(AssemblyName),
+                SnapshotPath = string.Copy(SnapshotPath),
+                LaunchJson = string.Copy(LaunchJson),
+                Region = Region
+            };
+        }
+
+        private bool ValidateAssembly()
+        {
+            return !string.IsNullOrEmpty(AssemblyName) && Regex.Match(AssemblyName, "^[a-zA-Z0-9_.-]{5,64}$").Success;
+        }
+
+        private bool ValidateNameName()
+        {
+            return !string.IsNullOrEmpty(Name) && Regex.Match(Name, "^[a-z0-9_]{2,32}$").Success;
+        }
+    }
+
+    public enum DeploymentRegionCode
+    {
+        US,
+        EU
+    }
+
+    public class DeploymentInfo
+    {
+        /// <summary>
+        ///     The SpatialOS project that the deployment is running in.
+        /// </summary>
+        public string ProjectName { get; }
+
+        /// <summary>
+        ///     The name of the deployment.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        ///     The id of the deployment.
+        /// </summary>
+        public string Id { get; }
+    }
+
+    public class AssemblyConfig
+    {
+        /// <summary>
+        ///     The project to upload this assembly to.
+        /// </summary>
+        public string ProjectName { get; private set; }
+
+        /// <summary>
+        ///     The name of this assembly.
+        /// </summary>
+        public string AssemblyName { get; private set; }
+
+        public AssemblyConfig DeepCopy()
+        {
+            return new AssemblyConfig
+            {
+                ProjectName = string.Copy(ProjectName),
+                AssemblyName = string.Copy(AssemblyName)
+            };
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
@@ -91,14 +91,14 @@ namespace Improbable.Gdk.DeploymentManager
         /// <summary>
         ///     The project to upload this assembly to.
         /// </summary>
-        public string ProjectName { get; private set; }
+        public string ProjectName;
 
         /// <summary>
         ///     The name of this assembly.
         /// </summary>
-        public string AssemblyName { get; private set; }
+        public string AssemblyName;
 
-        public AssemblyConfig DeepCopy()
+        internal AssemblyConfig DeepCopy()
         {
             return new AssemblyConfig
             {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf76cbf3c2088f14db1756f879d7adef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description

* Created objects to represent: a deployment configuration for launching, deployment info received from the console, and assembly configuration for uploading.
* Factored out commands to take these as arguments. Note that I planned here that I will refactor the dotnet project to have named arguments.

**There are some TODOs in this change - that is okay for now**

--- 

Notes on `WrappedTask<TResult, TContext>`: This allows us to bundle the context for a task, the task itself, and the cancellation source into one object. The reason we bundle the context is that whoever called the command can print useful messages for a user when the task finishes without holding onto a copy of the source object themselves.

The fields inside the UI may have changed in the meantime - hence the `DeepCopy` on the configurations. 

Note that this isn't required for the `DeploymentInfo` as we receive this off the "wire" and is immutable (getter only properties). The reason we can't make the other configs immutable is that the UI will be writing to a copy of these when the user changes the fields.

#### Tests
None yet.

#### Documentation
Will do this at the end.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jessicafalk @jared-improbable 
