### PR TITLE
Deployment launcher refactor part 2 - Underlying dotnet project refactor

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Create.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Create.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Security.Cryptography;
+using Google.Protobuf.WellKnownTypes;
+using Improbable.SpatialOS.Deployment.V1Alpha1;
+using Improbable.SpatialOS.PlayerAuth.V2Alpha1;
+using Improbable.SpatialOS.Snapshot.V1Alpha1;
+using Newtonsoft.Json.Linq;
+
+namespace Improbable.Gdk.DeploymentLauncher.Commands
+{
+    public static class Create
+    {
+        public static int CreateDeployment(Options.Create options)
+        {
+            return CreateDeployment(options, opts => File.ReadAllText(opts.LaunchJsonPath));
+        }
+
+        public static int CreateSimulatedPlayerDeployment(Options.CreateSimulated options)
+        {
+            return CreateDeployment(options, opts => ModifySimulatedPlayerLaunchJson(options));
+        }
+
+        private static int CreateDeployment<TOptions>(TOptions options, Func<TOptions, string> getLaunchConfigJson)
+            where TOptions : Options.Create
+        {
+            var snapshotServiceClient = SnapshotServiceClient.Create();
+            var deploymentServiceClient = DeploymentServiceClient.Create();
+
+            try
+            {
+                var deployment = new Deployment
+                {
+                    AssemblyId = options.AssemblyName,
+                    LaunchConfig = new LaunchConfig
+                    {
+                        ConfigJson = getLaunchConfigJson(options)
+                    },
+                    Name = options.DeploymentName,
+                    ProjectName = options.ProjectName,
+                    RegionCode = options.Region
+                };
+
+                if (options.SnapshotPath != null)
+                {
+                    var snapshotId = UploadSnapshot(snapshotServiceClient, options.SnapshotPath, options.ProjectName,
+                        options.DeploymentName);
+
+                    if (snapshotId.Length == 0)
+                    {
+                        // TODO: Write out error.
+                        return 1;
+                    }
+
+                    deployment.StartingSnapshotId = snapshotId;
+                }
+
+                if (options.Tags != null)
+                {
+                    foreach (var tag in options.Tags)
+                    {
+                        deployment.Tag.Add(tag);
+                    }
+                }
+
+                deploymentServiceClient.CreateDeployment(new CreateDeploymentRequest
+                {
+                    Deployment = deployment
+                }).PollUntilCompleted();
+            }
+            catch (Grpc.Core.RpcException e)
+            {
+                if (e.Status.StatusCode == Grpc.Core.StatusCode.NotFound)
+                {
+                    // TODO: Write out error.
+                    return 1;
+                }
+
+                throw;
+            }
+
+            return 0;
+        }
+
+        private static string ModifySimulatedPlayerLaunchJson(Options.CreateSimulated options)
+        {
+            var playerAuthServiceClient = PlayerAuthServiceClient.Create();
+
+            // Create development authentication token used by the simulated players.
+            var dat = playerAuthServiceClient.CreateDevelopmentAuthenticationToken(
+                new CreateDevelopmentAuthenticationTokenRequest
+                {
+                    Description = "DAT for sim worker deployment.",
+                    Lifetime = Duration.FromTimeSpan(new TimeSpan(7, 0, 0, 0)),
+                    ProjectName = options.ProjectName
+                });
+
+            // Add worker flags to sim deployment JSON.
+            var devAuthTokenIdFlag = new JObject
+            {
+                { "name", $"{options.FlagPrefix}_simulated_players_dev_auth_token_id" },
+                { "value", dat.DevelopmentAuthenticationToken.Id }
+            };
+
+            var targetDeploymentFlag = new JObject
+            {
+                { "name", $"{options.FlagPrefix}_simulated_players_target_deployment" },
+                { "value", options.TargetDeployment }
+            };
+
+            var launchConfigRaw = File.ReadAllText(options.LaunchJsonPath);
+            dynamic launchConfig = JObject.Parse(launchConfigRaw);
+
+            for (var i = 0; i < launchConfig.workers.Count; ++i)
+            {
+                // TODO: Un-hardcode this.
+                if (launchConfig.workers[i].worker_type == "SimulatedPlayerCoordinator")
+                {
+                    launchConfig.workers[i].flags.Add(devAuthTokenIdFlag);
+                    launchConfig.workers[i].flags.Add(targetDeploymentFlag);
+                }
+            }
+
+            return launchConfig.ToString();
+        }
+
+        private static string UploadSnapshot(SnapshotServiceClient client, string snapshotPath, string projectName,
+            string deploymentName)
+        {
+            Console.WriteLine($"Uploading {snapshotPath} to project {projectName}");
+
+            // Read snapshot.
+            var bytes = File.ReadAllBytes(snapshotPath);
+
+            if (bytes.Length == 0)
+            {
+                Console.Error.WriteLine($"Unable to load {snapshotPath}. Does the file exist?");
+                return string.Empty;
+            }
+
+            // Create HTTP endpoint to upload to.
+            var snapshotToUpload = new Snapshot
+            {
+                ProjectName = projectName,
+                DeploymentName = deploymentName
+            };
+
+            using (var md5 = MD5.Create())
+            {
+                snapshotToUpload.Checksum = Convert.ToBase64String(md5.ComputeHash(bytes));
+                snapshotToUpload.Size = bytes.Length;
+            }
+
+            var uploadSnapshotResponse =
+                client.UploadSnapshot(new UploadSnapshotRequest { Snapshot = snapshotToUpload });
+            snapshotToUpload = uploadSnapshotResponse.Snapshot;
+
+            // Upload content.
+            var httpRequest = WebRequest.Create(uploadSnapshotResponse.UploadUrl) as HttpWebRequest;
+            httpRequest.Method = "PUT";
+            httpRequest.ContentLength = snapshotToUpload.Size;
+            httpRequest.Headers.Set("Content-MD5", snapshotToUpload.Checksum);
+
+            using (var dataStream = httpRequest.GetRequestStream())
+            {
+                dataStream.Write(bytes, 0, bytes.Length);
+            }
+
+            // Block until we have a response.
+            httpRequest.GetResponse();
+
+            // Confirm that the snapshot was uploaded successfully.
+            var confirmUploadResponse = client.ConfirmUpload(new ConfirmUploadRequest
+            {
+                DeploymentName = snapshotToUpload.DeploymentName,
+                Id = snapshotToUpload.Id,
+                ProjectName = snapshotToUpload.ProjectName
+            });
+
+            return confirmUploadResponse.Snapshot.Id;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/List.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/List.cs
@@ -1,0 +1,28 @@
+using System;
+using Improbable.SpatialOS.Deployment.V1Alpha1;
+
+namespace Improbable.Gdk.DeploymentLauncher.Commands
+{
+    public static class List
+    {
+        public static int ListDeployments(Options.List options)
+        {
+            var deploymentServiceClient = DeploymentServiceClient.Create();
+            var listDeploymentsResult = deploymentServiceClient.ListDeployments(new ListDeploymentsRequest
+            {
+                ProjectName = options.ProjectName
+            });
+
+            foreach (var deployment in listDeploymentsResult)
+            {
+                if (deployment.Status == Deployment.Types.Status.Running)
+                {
+                    // TODO: Write out results properly.
+                    Console.WriteLine($"<deployment> {deployment.Id} {deployment.Name}");
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/List.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/List.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Linq;
 using Improbable.SpatialOS.Deployment.V1Alpha1;
 
 namespace Improbable.Gdk.DeploymentLauncher.Commands
@@ -13,14 +13,8 @@ namespace Improbable.Gdk.DeploymentLauncher.Commands
                 ProjectName = options.ProjectName
             });
 
-            foreach (var deployment in listDeploymentsResult)
-            {
-                if (deployment.Status == Deployment.Types.Status.Running)
-                {
-                    // TODO: Write out results properly.
-                    Console.WriteLine($"<deployment> {deployment.Id} {deployment.Name}");
-                }
-            }
+            Ipc.WriteDeploymentInfo(listDeploymentsResult.Where(deployment =>
+                deployment.Status == Deployment.Types.Status.Running));
 
             return 0;
         }

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Stop.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Stop.cs
@@ -1,4 +1,3 @@
-using System;
 using Improbable.SpatialOS.Deployment.V1Alpha1;
 
 namespace Improbable.Gdk.DeploymentLauncher.Commands
@@ -21,13 +20,12 @@ namespace Improbable.Gdk.DeploymentLauncher.Commands
             {
                 if (e.Status.StatusCode == Grpc.Core.StatusCode.NotFound)
                 {
-                    // TODO: Write out error properly.
-                    Console.WriteLine("<error:unknown-deployment>");
+                    Ipc.WriteError(Ipc.ErrorCode.NotFound,
+                        $"Could not find deployment with ID {options.DeploymentId} in project {options.ProjectName}");
+                    return 1;
                 }
-                else
-                {
-                    throw;
-                }
+
+                throw;
             }
 
             return 0;

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Stop.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Stop.cs
@@ -1,0 +1,36 @@
+using System;
+using Improbable.SpatialOS.Deployment.V1Alpha1;
+
+namespace Improbable.Gdk.DeploymentLauncher.Commands
+{
+    public static class Stop
+    {
+        public static int StopDeployment(Options.Stop options)
+        {
+            var deploymentServiceClient = DeploymentServiceClient.Create();
+
+            try
+            {
+                deploymentServiceClient.StopDeployment(new StopDeploymentRequest
+                {
+                    Id = options.DeploymentId,
+                    ProjectName = options.ProjectName
+                });
+            }
+            catch (Grpc.Core.RpcException e)
+            {
+                if (e.Status.StatusCode == Grpc.Core.StatusCode.NotFound)
+                {
+                    // TODO: Write out error properly.
+                    Console.WriteLine("<error:unknown-deployment>");
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.4.3" />
-    <PackageReference Include="Improbable.SpatialOS.Platform" Version="13.5.1" />
+    <PackageReference Include="Improbable.SpatialOS.Platform" Version="13.6.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.4.3" />
     <PackageReference Include="Improbable.SpatialOS.Platform" Version="13.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Ipc.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Ipc.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Improbable.SpatialOS.Deployment.V1Alpha1;
+using Newtonsoft.Json;
+
+namespace Improbable.Gdk.DeploymentLauncher
+{
+    /// <summary>
+    ///     Methods for inter-process communication with the parent process (Unity). ALl via JSON.
+    /// </summary>
+    public static class Ipc
+    {
+        public enum ErrorCode : uint
+        {
+            FileNotFound = 1,
+            Unauthenticated = 2,
+            NotFound = 3,
+            UnknownGrpcError = 4,
+            Other = 5
+        }
+
+        public static void WriteError(ErrorCode code, string message)
+        {
+            var json = JsonConvert.SerializeObject(new Error(code, message));
+            Console.Error.WriteLine(json);
+        }
+
+        public static void WriteDeploymentInfo(IEnumerable<Deployment> deployments)
+        {
+            var json = JsonConvert.SerializeObject(deployments.Select(depl => new InternalDeployment(depl)).ToList());
+            Console.WriteLine(json);
+        }
+
+        private struct Error
+        {
+            public uint Code;
+            public string Message;
+
+            public Error(ErrorCode code, string message)
+            {
+                Code = (uint) code;
+                Message = message;
+            }
+        }
+
+        private struct InternalDeployment
+        {
+            public string Id;
+            public string Name;
+
+            public InternalDeployment(Deployment deployment)
+            {
+                Id = deployment.Id;
+                Name = deployment.Name;
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Options.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Options.cs
@@ -26,18 +26,23 @@ namespace Improbable.Gdk.DeploymentLauncher
             [Option("region", Required = true, HelpText = "The region to launch the deployment in.")]
             public string Region { get; set; }
 
-            [Option("tags", Required = false, HelpText = "Tags to add to this deployment. Comma separated", Separator = ',')]
+            [Option("tags", Required = false, HelpText = "Tags to add to this deployment. Comma separated",
+                Separator = ',')]
             public IEnumerable<string> Tags { get; set; }
         }
 
         [Verb("create-sim", HelpText = "Create a simulated player deployment")]
         public class CreateSimulated : Create
         {
-            [Option("target_deployment", Required = true, HelpText = "The deployment to connect the simulated players to.")]
+            [Option("target_deployment", Required = true,
+                HelpText = "The deployment to connect the simulated players to.")]
             public string TargetDeployment { get; set; }
 
-            [Option("flag-prefix", Required = true, HelpText = "The prefix used in setting the worker flags.")]
+            [Option("flag_prefix", Required = true, HelpText = "The prefix used in setting the worker flags.")]
             public string FlagPrefix { get; set; }
+
+            [Option("simulated_coordinator_worker_type", Required = true, HelpText = "The worker type for the simulated player coordinator.")]
+            public string SimulatedCoordinatorWorkerType { get; set; }
         }
 
         [Verb("stop", HelpText = "Stop a running deployment.")]

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Options.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Options.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using CommandLine;
+
+namespace Improbable.Gdk.DeploymentLauncher
+{
+    public class Options
+    {
+        [Verb("create", HelpText = "Create a deployment.")]
+        public class Create
+        {
+            [Option("project_name", Required = true, HelpText = "The SpatialOS project name")]
+            public string ProjectName { get; set; }
+
+            [Option("assembly_name", Required = true, HelpText = "The assembly to use in the deployment.")]
+            public string AssemblyName { get; set; }
+
+            [Option("deployment_name", Required = true, HelpText = "The name of the deployment to create.")]
+            public string DeploymentName { get; set; }
+
+            [Option("launch_json_path", Required = true, HelpText = "The path to the launch json file.")]
+            public string LaunchJsonPath { get; set; }
+
+            [Option("snapshot", Required = false, HelpText = "The path to the snapshot.")]
+            public string SnapshotPath { get; set; }
+
+            [Option("region", Required = true, HelpText = "The region to launch the deployment in.")]
+            public string Region { get; set; }
+
+            [Option("tags", Required = false, HelpText = "Tags to add to this deployment. Comma separated", Separator = ',')]
+            public IEnumerable<string> Tags { get; set; }
+        }
+
+        [Verb("create-sim", HelpText = "Create a simulated player deployment")]
+        public class CreateSimulated : Create
+        {
+            [Option("target_deployment", Required = true, HelpText = "The deployment to connect the simulated players to.")]
+            public string TargetDeployment { get; set; }
+
+            [Option("flag-prefix", Required = true, HelpText = "The prefix used in setting the worker flags.")]
+            public string FlagPrefix { get; set; }
+        }
+
+        [Verb("stop", HelpText = "Stop a running deployment.")]
+        public class Stop
+        {
+            [Option("project_name", Required = true, HelpText = "The SpatialOS project name")]
+            public string ProjectName { get; set; }
+
+            [Option("deployment_id", Required = true, HelpText = "The ID of the deployment to stop.")]
+            public string DeploymentId { get; set; }
+        }
+
+        [Verb("list", HelpText = "List deployments for a given project.")]
+        public class List
+        {
+            [Option("project_name", Required = true, HelpText = "The SpatialOS project name")]
+            public string ProjectName { get; set; }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
@@ -2,327 +2,56 @@ using System;
 using System.IO;
 using System.Net;
 using System.Security.Cryptography;
+using CommandLine;
 using Google.Protobuf.WellKnownTypes;
 using Improbable.SpatialOS.Deployment.V1Alpha1;
 using Improbable.SpatialOS.PlayerAuth.V2Alpha1;
 using Improbable.SpatialOS.Snapshot.V1Alpha1;
 using Newtonsoft.Json.Linq;
 
-namespace Improbable
+namespace Improbable.Gdk.DeploymentLauncher
 {
     internal class Program
     {
-        private static string UploadSnapshot(SnapshotServiceClient client, string snapshotPath, string projectName,
-            string deploymentName)
-        {
-            Console.WriteLine($"Uploading {snapshotPath} to project {projectName}");
-
-            // Read snapshot.
-            var bytes = File.ReadAllBytes(snapshotPath);
-
-            if (bytes.Length == 0)
-            {
-                Console.Error.WriteLine($"Unable to load {snapshotPath}. Does the file exist?");
-                return string.Empty;
-            }
-
-            // Create HTTP endpoint to upload to.
-            var snapshotToUpload = new Snapshot
-            {
-                ProjectName = projectName,
-                DeploymentName = deploymentName
-            };
-
-            using (var md5 = MD5.Create())
-            {
-                snapshotToUpload.Checksum = Convert.ToBase64String(md5.ComputeHash(bytes));
-                snapshotToUpload.Size = bytes.Length;
-            }
-
-            var uploadSnapshotResponse =
-                client.UploadSnapshot(new UploadSnapshotRequest { Snapshot = snapshotToUpload });
-            snapshotToUpload = uploadSnapshotResponse.Snapshot;
-
-            // Upload content.
-            var httpRequest = WebRequest.Create(uploadSnapshotResponse.UploadUrl) as HttpWebRequest;
-            httpRequest.Method = "PUT";
-            httpRequest.ContentLength = snapshotToUpload.Size;
-            httpRequest.Headers.Set("Content-MD5", snapshotToUpload.Checksum);
-
-            using (var dataStream = httpRequest.GetRequestStream())
-            {
-                dataStream.Write(bytes, 0, bytes.Length);
-            }
-
-            // Block until we have a response.
-            httpRequest.GetResponse();
-
-            // Confirm that the snapshot was uploaded successfully.
-            var confirmUploadResponse = client.ConfirmUpload(new ConfirmUploadRequest
-            {
-                DeploymentName = snapshotToUpload.DeploymentName,
-                Id = snapshotToUpload.Id,
-                ProjectName = snapshotToUpload.ProjectName
-            });
-
-            return confirmUploadResponse.Snapshot.Id;
-        }
-
-        private static int CreateDeployment(string[] args)
-        {
-            bool launchSimPlayerDeployment = args.Length == 9;
-
-            var projectName = args[1];
-            var assemblyName = args[2];
-            var mainDeploymentName = args[3];
-            var mainDeploymentJson = args[4];
-            var mainDeploymentSnapshotFilePath = args[5];
-            var deploymentRegionCode = args[6];
-
-            var simDeploymentName = string.Empty;
-            var simDeploymentJson = string.Empty;
-
-            if (launchSimPlayerDeployment)
-            {
-                simDeploymentName = args[7];
-                simDeploymentJson = args[8];
-            }
-
-            // Create service clients.
-            var playerAuthServiceClient = PlayerAuthServiceClient.Create();
-            var snapshotServiceClient = SnapshotServiceClient.Create();
-            var deploymentServiceClient = DeploymentServiceClient.Create();
-
-            try
-            {
-                // Upload snapshots.
-                var mainSnapshotId = UploadSnapshot(snapshotServiceClient, mainDeploymentSnapshotFilePath, projectName,
-                    mainDeploymentName);
-
-                if (mainSnapshotId.Length == 0)
-                {
-                    return 1;
-                }
-
-                // Create main deployment.
-                var mainDeploymentConfig = new Deployment
-                {
-                    AssemblyId = assemblyName,
-                    LaunchConfig = new LaunchConfig
-                    {
-                        ConfigJson = File.ReadAllText(mainDeploymentJson)
-                    },
-                    Name = mainDeploymentName,
-                    ProjectName = projectName,
-                    StartingSnapshotId = mainSnapshotId,
-                    RegionCode = deploymentRegionCode
-                };
-
-                if (launchSimPlayerDeployment)
-                {
-                    // This tag needs to be added to allow simulated clients to connect using login
-                    // tokens generated with anonymous auth.
-                    mainDeploymentConfig.Tag.Add("dev_login");
-                }
-
-                Console.WriteLine(
-                    $"Creating the main deployment {mainDeploymentName} in project {projectName} with snapshot ID {mainSnapshotId}.");
-
-                var mainDeploymentCreateOp = deploymentServiceClient.CreateDeployment(new CreateDeploymentRequest
-                {
-                    Deployment = mainDeploymentConfig
-                }).PollUntilCompleted();
-
-                Console.WriteLine("Successfully created the main deployment.");
-
-                if (launchSimPlayerDeployment)
-                {
-                    // Create development authentication token used by the simulated players.
-                    var dat = playerAuthServiceClient.CreateDevelopmentAuthenticationToken(
-                        new CreateDevelopmentAuthenticationTokenRequest
-                        {
-                            Description = "DAT for sim worker deployment.",
-                            Lifetime = Duration.FromTimeSpan(new TimeSpan(7, 0, 0, 0)),
-                            ProjectName = projectName
-                        });
-
-                    // Add worker flags to sim deployment JSON.
-                    var devAuthTokenIdFlag = new JObject();
-                    devAuthTokenIdFlag.Add("name", "fps_simulated_players_dev_auth_token_id");
-                    devAuthTokenIdFlag.Add("value", dat.DevelopmentAuthenticationToken.Id);
-
-                    var targetDeploymentFlag = new JObject();
-                    targetDeploymentFlag.Add("name", "fps_simulated_players_target_deployment");
-                    targetDeploymentFlag.Add("value", mainDeploymentName);
-
-                    var simWorkerConfigJson = File.ReadAllText(simDeploymentJson);
-                    dynamic simWorkerConfig = JObject.Parse(simWorkerConfigJson);
-
-                    for (var i = 0; i < simWorkerConfig.workers.Count; ++i)
-                    {
-                        if (simWorkerConfig.workers[i].worker_type == "SimulatedPlayerCoordinator")
-                        {
-                            simWorkerConfig.workers[i].flags.Add(devAuthTokenIdFlag);
-                            simWorkerConfig.workers[i].flags.Add(targetDeploymentFlag);
-                        }
-                    }
-
-                    simWorkerConfigJson = simWorkerConfig.ToString();
-
-                    // Create simulated player deployment.
-                    var simDeploymentConfig = new Deployment
-                    {
-                        AssemblyId = assemblyName,
-                        LaunchConfig = new LaunchConfig
-                        {
-                            ConfigJson = simWorkerConfigJson
-                        },
-                        Name = simDeploymentName,
-                        ProjectName = projectName,
-                        RegionCode = deploymentRegionCode
-                    };
-
-                    simDeploymentConfig.Tag.Add("simulated_clients");
-
-                    Console.WriteLine($"Creating the simulated player deployment {simDeploymentName} in project {projectName}.");
-
-                    var simDeploymentCreateOp = deploymentServiceClient.CreateDeployment(new CreateDeploymentRequest
-                    {
-                        Deployment = simDeploymentConfig
-                    }).PollUntilCompleted();
-
-                    Console.WriteLine("Successfully created the simulated player deployment.");
-                }
-            }
-            catch (Grpc.Core.RpcException e)
-            {
-                if (e.Status.StatusCode == Grpc.Core.StatusCode.NotFound)
-                {
-                    Console.WriteLine(
-                        $"Unable to launch the deployment(s). This is likely because the project '{projectName}' or assembly '{assemblyName}' doesn't exist.");
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
-            return 0;
-        }
-
-        private static int StopDeployment(string[] args)
-        {
-            var projectName = args[1];
-            var deploymentId = args[2];
-
-            var deploymentServiceClient = DeploymentServiceClient.Create();
-
-            try
-            {
-                deploymentServiceClient.StopDeployment(new StopDeploymentRequest
-                {
-                    Id = deploymentId,
-                    ProjectName = projectName
-                });
-            }
-            catch (Grpc.Core.RpcException e)
-            {
-                if (e.Status.StatusCode == Grpc.Core.StatusCode.NotFound)
-                {
-                    Console.WriteLine("<error:unknown-deployment>");
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
-            return 0;
-        }
-
-        private static int ListDeployments(string[] args)
-        {
-            var projectName = args[1];
-
-            var deploymentServiceClient = DeploymentServiceClient.Create();
-            var listDeploymentsResult = deploymentServiceClient.ListDeployments(new ListDeploymentsRequest
-            {
-                ProjectName = projectName
-            });
-
-            foreach (var deployment in listDeploymentsResult)
-            {
-                if (deployment.Status == Deployment.Types.Status.Running)
-                {
-                    Console.WriteLine($"<deployment> {deployment.Id} {deployment.Name}");
-                }
-            }
-
-            return 0;
-        }
-
-        private static void ShowUsage()
-        {
-            Console.WriteLine("Usage:");
-            Console.WriteLine(
-                "DeploymentManager create <project-name> <assembly-name> <main-deployment-name> <main-deployment-json> <main-deployment-snapshot> <main-deployment-region> [<sim-deployment-name> <sim-deployment-json>]");
-            Console.WriteLine("DeploymentManager stop <project-name> <deployment-id>");
-            Console.WriteLine("DeploymentManager list <project-name>");
-        }
-
         private static int Main(string[] args)
         {
-            if (args.Length == 0 ||
-                args[0] == "create" && (args.Length != 9 && args.Length != 7) ||
-                args[0] == "stop" && args.Length != 3 ||
-                args[0] == "list" && args.Length != 2)
-            {
-                ShowUsage();
-                return 1;
-            }
-
             try
             {
-                if (args[0] == "create")
-                {
-                    return CreateDeployment(args);
-                }
-
-                if (args[0] == "stop")
-                {
-                    return StopDeployment(args);
-                }
-
-                if (args[0] == "list")
-                {
-                    return ListDeployments(args);
-                }
+                return Parser.Default.ParseArguments<Options.Create, Options.CreateSimulated, Options.Stop, Options.List>(args)
+                    .MapResult(
+                        (Options.Create createOptions) => Commands.Create.CreateDeployment(createOptions),
+                        (Options.CreateSimulated createOptions) => Commands.Create.CreateSimulatedPlayerDeployment(createOptions),
+                        (Options.Stop stopOptions) => Commands.Stop.StopDeployment(stopOptions),
+                        (Options.List listOptions) => Commands.List.ListDeployments(listOptions),
+                        errs => 1
+                    );
             }
             catch (Grpc.Core.RpcException e)
             {
+                // TODO: Write out in a nice way.
                 if (e.Status.StatusCode == Grpc.Core.StatusCode.Unauthenticated)
                 {
                     Console.WriteLine("<error:unauthenticated>");
+                    return 1;
                 }
-                else
-                {
-                    Console.Error.WriteLine($"Encountered an unknown gRPC error. Exception = {e.ToString()}");
-                }
+
+                Console.Error.WriteLine($"Encountered an unknown gRPC error. Exception = {e.ToString()}");
+                return 1;
             }
             catch (ArgumentNullException e)
             {
+                // TODO: Look and see if this was fixed.
                 // This is here to work around WF-464, present as of Platform SDK version 13.5.0.
                 if (e.ParamName == "path")
                 {
                     Console.WriteLine("<error:authentication>");
+                    return 1;
                 }
                 else
                 {
                     throw;
                 }
             }
-
-            return 1;
         }
     }
 }


### PR DESCRIPTION
#### Description
* Refactored the underlying `DeploymentLauncher` dotnet project. It should nearly now be sufficiently generic to be used in any SpatialOS project (last hardcoded part is the simulated player coordinator worker I think)
* Used `CommandLineParser` NuGet package to do argument and command parsing
* Simplified how the deployment creation happens. Expectation is that you would call this twice with `create ...`  and then `create-sim ...` instead of one call. This is more flexible for the future.

---

**There are still TODOs in this - need to figure out the best way to IPC between dotnet <> Unity.**

Also need to change the release QA scripts for BK.

#### Tests
It compiled - properly testing is yet to come.
