### PR TITLE
Remove `max_bridge_module_load` flag

### DIFF
--- a/cloud_launch_large.json
+++ b/cloud_launch_large.json
@@ -8,13 +8,7 @@
     "dimensions": {
       "xMeters": 1800,
       "zMeters": 1800
-    },
-    "legacy_flags": [
-      {
-        "name": "max_bridge_module_load",
-        "value": "500"
-      }
-    ]
+    }
   },
   "load_balancing": {
     "layer_configurations": [

--- a/cloud_launch_large_sim_players.json
+++ b/cloud_launch_large_sim_players.json
@@ -8,13 +8,7 @@
     "dimensions": {
       "xMeters": 1800,
       "zMeters": 1800
-    },
-    "legacy_flags": [
-      {
-        "name": "max_bridge_module_load",
-        "value": "500"
-      }
-    ]
+    }
   },
   "load_balancing": {
     "layer_configurations" : [


### PR DESCRIPTION
#### Description
Remove the `max_bridge_module_load` flag from cloud launch large configs

#### Tests
- [x] bk premerge
- [x] bk release qa

Will run a deployment overnight to validate performance.

#### Documentation
n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
