### PR TITLE
Use the token secret instead of DAT ID in deployment launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added
+
+- Added session-based gameplay, hidden behind the `Use Session Based Flow` feature flag.
+
+### Changed
+
+- Changed connection and player-spawn flow.
+- Updated the available prefabs and textures.
+
+### Internal
+
+- Updated the deployment launcher to use the DAT secret instead of the ID.
+
 ## `0.2.1` - 2019-04-15
 
 ### Changed

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Improbable.SpatialOS.Platform" Version="13.5.1" />
+    <PackageReference Include="Improbable.SpatialOS.Platform" Version="13.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
@@ -149,7 +149,7 @@ namespace Improbable
                     // Add worker flags to sim deployment JSON.
                     var devAuthTokenIdFlag = new JObject();
                     devAuthTokenIdFlag.Add("name", "fps_simulated_players_dev_auth_token_id");
-                    devAuthTokenIdFlag.Add("value", dat.DevelopmentAuthenticationToken.Id);
+                    devAuthTokenIdFlag.Add("value", dat.TokenSecret);
 
                     var targetDeploymentFlag = new JObject();
                     targetDeploymentFlag.Add("name", "fps_simulated_players_target_deployment");


### PR DESCRIPTION
#### Description

- upgrade platform sdk to 13.7.1
- use the token secret instead of DAT ID in deployment launcher

#### Tests

ran deployments, confirmed a secret is set instead of the DAT ID

#### Documentation

changelog update

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
