### PR TITLE
Use DAT secret instead of ID

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Create.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Create.cs
@@ -107,7 +107,7 @@ namespace Improbable.Gdk.DeploymentLauncher.Commands
             var devAuthTokenIdFlag = new JObject
             {
                 { "name", $"{options.FlagPrefix}_simulated_players_dev_auth_token_id" },
-                { "value", dat.DevelopmentAuthenticationToken.Id }
+                { "value", dat.TokenSecret }
             };
 
             var targetDeploymentFlag = new JObject

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.4.3" />
-    <PackageReference Include="Improbable.SpatialOS.Platform" Version="13.6.2" />
+    <PackageReference Include="Improbable.SpatialOS.Platform" Version="13.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
#### Description

- upgrade dpl launcher platform sdk to 13.7.1
- use DAT secret instead of ID

#### Tests

- [x] launch a dpl with simplayers

#### Documentation

n/a

**Did you remember a changelog entry?**
Jamie will do it when merging the main experimental branch

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
