### PR TITLE
Update cloud launch templates

### DIFF
--- a/cloud_launch_large.json
+++ b/cloud_launch_large.json
@@ -1,5 +1,5 @@
 {
-  "template": "w4_r1000_e1",
+  "template": "w4_r1000_e10",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {

--- a/cloud_launch_small.json
+++ b/cloud_launch_small.json
@@ -1,5 +1,5 @@
 {
-  "template": "w4_r1000_e1",
+  "template": "w4_r1000_e10",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {


### PR DESCRIPTION
#### Description

Updated cloud launch templates to use the latest `w4_r1000_e10` template. Its topology is identical to that of the old template.

#### Tests

- [x] buildkite release qa

#### Documentation

n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
