### PR TITLE
Add Listing + Stopping to Deployment Launcher Rewrite

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Ipc.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Ipc.cs
@@ -53,7 +53,7 @@ namespace Improbable.Gdk.DeploymentLauncher
         {
             public string Id;
             public string Name;
-            public string StartTime;
+            public long StartTime;
             public string Region;
             public List<string> Tags;
             public Dictionary<string, int> Workers;
@@ -62,10 +62,7 @@ namespace Improbable.Gdk.DeploymentLauncher
             {
                 Id = deployment.Id;
                 Name = deployment.Name;
-
-                var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-                StartTime = epoch.AddSeconds(deployment.StartTime.Seconds).ToString();
-
+                StartTime = deployment.StartTime.Seconds;
                 Region = deployment.RegionCode;
                 Tags = deployment.Tag.ToList();
                 Workers = deployment.WorkerConnectionCapacities

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Ipc.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Ipc.cs
@@ -53,11 +53,24 @@ namespace Improbable.Gdk.DeploymentLauncher
         {
             public string Id;
             public string Name;
+            public string StartTime;
+            public string Region;
+            public List<string> Tags;
+            public Dictionary<string, int> Workers;
 
             public InternalDeployment(Deployment deployment)
             {
                 Id = deployment.Id;
                 Name = deployment.Name;
+
+                var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                StartTime = epoch.AddSeconds(deployment.StartTime.Seconds).ToString();
+
+                Region = deployment.RegionCode;
+                Tags = deployment.Tag.ToList();
+                Workers = deployment.WorkerConnectionCapacities
+                    .Select(capacity => (capacity.WorkerType, capacity.MaxCapacity - capacity.RemainingCapacity))
+                    .ToDictionary(pair => pair.WorkerType, pair => pair.Item2);
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Program.cs
@@ -47,6 +47,11 @@ namespace Improbable.Gdk.DeploymentLauncher
                 Ipc.WriteError(Ipc.ErrorCode.UnknownGrpcError, e.ToString());
                 return ErrorExitCode;
             }
+            catch (SpatialOS.Platform.Common.NoRefreshTokenFoundException)
+            {
+                Ipc.WriteError(Ipc.ErrorCode.Unauthenticated, "");
+                return ErrorExitCode;
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs
@@ -5,7 +5,7 @@ using Improbable.Gdk.Tools;
 
 namespace Improbable.Gdk.DeploymentManager.Commands
 {
-    public static class Assembly
+    internal static class Assembly
     {
         public static WrappedTask<RedirectedProcessResult, AssemblyConfig> UploadAsync(AssemblyConfig config)
         {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Authentication.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Authentication.cs
@@ -5,7 +5,7 @@ using Improbable.Gdk.Tools;
 
 namespace Improbable.Gdk.DeploymentManager.Commands
 {
-    public static class Authentication
+    internal static class Authentication
     {
         private static readonly string[] AuthArgs =
         {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Authentication.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Authentication.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Improbable.Gdk.Tools;
+
+namespace Improbable.Gdk.DeploymentManager.Commands
+{
+    public static class Authentication
+    {
+        public static WrappedTask<RedirectedProcessResult, int> Authenticate()
+        {
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+            var args = new List<string>
+            {
+                "auth",
+                "login",
+                "--json_output"
+            };
+
+            var task = Task.Run(async () => await RedirectedProcess.Command(Tools.Common.SpatialBinary)
+                .InDirectory(Tools.Common.SpatialProjectRootDir)
+                .WithArgs(args.ToArray())
+                .RedirectOutputOptions(OutputRedirectBehaviour.RedirectStdOut |
+                    OutputRedirectBehaviour.RedirectStdErr | OutputRedirectBehaviour.ProcessSpatialOutput)
+                .RunAsync(token));
+
+            return new WrappedTask<RedirectedProcessResult, int>
+            {
+                Task = task,
+                CancelSource = source,
+                Context = 0
+            };
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Authentication.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Authentication.cs
@@ -7,21 +7,21 @@ namespace Improbable.Gdk.DeploymentManager.Commands
 {
     public static class Authentication
     {
+        private static readonly string[] AuthArgs =
+        {
+            "auth",
+            "login",
+            "--json_output"
+        };
+
         public static WrappedTask<RedirectedProcessResult, int> Authenticate()
         {
             var source = new CancellationTokenSource();
             var token = source.Token;
 
-            var args = new List<string>
-            {
-                "auth",
-                "login",
-                "--json_output"
-            };
-
             var task = Task.Run(async () => await RedirectedProcess.Command(Tools.Common.SpatialBinary)
                 .InDirectory(Tools.Common.SpatialProjectRootDir)
-                .WithArgs(args.ToArray())
+                .WithArgs(AuthArgs)
                 .RedirectOutputOptions(OutputRedirectBehaviour.RedirectStdOut |
                     OutputRedirectBehaviour.RedirectStdErr | OutputRedirectBehaviour.ProcessSpatialOutput)
                 .RunAsync(token));

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Authentication.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Authentication.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec259ee607885f24ebec1c0f13ef8c62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.DeploymentManager.Commands
             Tools.Common.GetPackagePath("com.improbable.gdk.deploymentlauncher"),
             ".DeploymentLauncher/DeploymentLauncher.csproj"));
 
-        public static WrappedTask<Result<RedirectedProcessResult, Ipc.Error>, BaseDeploymentConfig> LaunchAsync(string projectName, string assemblyName, BaseDeploymentConfig config)
+        public static WrappedTask<Result<RedirectedProcessResult, Ipc.Error>, (string, string, BaseDeploymentConfig)> LaunchAsync(string projectName, string assemblyName, BaseDeploymentConfig config)
         {
             var source = new CancellationTokenSource();
             var token = source.Token;
@@ -26,13 +26,13 @@ namespace Improbable.Gdk.DeploymentManager.Commands
             args.Add($"--project_name={projectName}");
             args.Add($"--assembly_name={assemblyName}");
 
-            return new WrappedTask<Result<RedirectedProcessResult, Ipc.Error>, BaseDeploymentConfig>
+            return new WrappedTask<Result<RedirectedProcessResult, Ipc.Error>, (string, string, BaseDeploymentConfig)>
             {
                 Task = RunDeploymentLauncher(args,
                     OutputRedirectBehaviour.None, token,
                     RetrieveIpcError),
                 CancelSource = source,
-                Context = config.DeepCopy()
+                Context = (projectName, assemblyName, config.DeepCopy())
             };
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
@@ -9,7 +9,7 @@ using Improbable.Gdk.Tools;
 
 namespace Improbable.Gdk.DeploymentManager.Commands
 {
-    public static class Deployment
+    internal static class Deployment
     {
         private static string DeploymentLauncherProjectPath = Path.GetFullPath(Path.Combine(
             Tools.Common.GetPackagePath("com.improbable.gdk.deploymentlauncher"),

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Deployment.cs
@@ -79,7 +79,7 @@ namespace Improbable.Gdk.DeploymentManager.Commands
 
             return new WrappedTask<Result<List<DeploymentInfo>, Ipc.Error>, string>
             {
-                Task = RunDeploymentLauncher(args, OutputRedirectBehaviour.RedirectStdErr, token,
+                Task = RunDeploymentLauncher(args, OutputRedirectBehaviour.None, token,
                     res => RetrieveDeploymentList(res, projectName)),
                 CancelSource = source,
                 Context = projectName

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/WrappedTask.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/WrappedTask.cs
@@ -4,7 +4,12 @@ using System.Threading.Tasks;
 
 namespace Improbable.Gdk.DeploymentManager.Commands
 {
-    public class WrappedTask<TResult, TContext> : IDisposable, IWrappedTask
+    /// <summary>
+    ///     Wraps a task, the context in which it was started, and a cancellation source for that task together.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the task result.</typeparam>
+    /// <typeparam name="TContext">The context of the task.</typeparam>
+    internal class WrappedTask<TResult, TContext> : IDisposable, IWrappedTask
     {
         public Task<TResult> Task;
         public CancellationTokenSource CancelSource;
@@ -32,7 +37,10 @@ namespace Improbable.Gdk.DeploymentManager.Commands
         }
     }
 
-    public interface IWrappedTask
+    /// <summary>
+    ///     An interface that allows us to interact with a WrappedTask in a type erased way.
+    /// </summary>
+    internal interface IWrappedTask
     {
         bool IsDone();
         void Cancel();

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/WrappedTask.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/WrappedTask.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Improbable.Gdk.DeploymentManager.Commands
 {
-    public class WrappedTask<TResult, TContext> : IDisposable
+    public class WrappedTask<TResult, TContext> : IDisposable, IWrappedTask
     {
         public Task<TResult> Task;
         public CancellationTokenSource CancelSource;
@@ -15,5 +15,27 @@ namespace Improbable.Gdk.DeploymentManager.Commands
             Task?.Dispose();
             CancelSource?.Dispose();
         }
+
+        public bool IsDone()
+        {
+            return Task.IsCompleted;
+        }
+
+        public void Cancel()
+        {
+            CancelSource.Cancel();
+        }
+
+        public void Wait()
+        {
+            Task.Wait();
+        }
+    }
+
+    public interface IWrappedTask
+    {
+        bool IsDone();
+        void Cancel();
+        void Wait();
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
@@ -9,7 +9,7 @@ using UnityEngine.Serialization;
 namespace Improbable.Gdk.DeploymentManager
 {
     [Serializable]
-    public class DeploymentConfig
+    internal class DeploymentConfig
     {
         public class Errors
         {
@@ -124,7 +124,7 @@ namespace Improbable.Gdk.DeploymentManager
     ///     Configuration that is specific to simulated player deployments.
     /// </summary>
     [Serializable]
-    public class SimulatedPlayerDeploymentConfig : BaseDeploymentConfig
+    internal class SimulatedPlayerDeploymentConfig : BaseDeploymentConfig
     {
         /// <summary>
         ///     The name of the deployment that the simulated players should connect into.
@@ -178,7 +178,7 @@ namespace Improbable.Gdk.DeploymentManager
     }
 
     [Serializable]
-    public class BaseDeploymentConfig
+    internal class BaseDeploymentConfig
     {
         /// <summary>
         ///     The name of the deployment to launch.
@@ -354,13 +354,13 @@ namespace Improbable.Gdk.DeploymentManager
         }
     }
 
-    public enum DeploymentRegionCode
+    internal enum DeploymentRegionCode
     {
         US,
         EU
     }
 
-    public class DeploymentInfo
+    internal class DeploymentInfo
     {
         /// <summary>
         ///     The SpatialOS project that the deployment is running in.
@@ -418,7 +418,7 @@ namespace Improbable.Gdk.DeploymentManager
     }
 
     [Serializable]
-    public class AssemblyConfig
+    internal class AssemblyConfig
     {
         /// <summary>
         ///     The name of the SpatialOS project for this assembly.

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
@@ -365,23 +365,52 @@ namespace Improbable.Gdk.DeploymentManager
         /// <summary>
         ///     The SpatialOS project that the deployment is running in.
         /// </summary>
-        public string ProjectName { get; }
+        public string ProjectName { get; private set; }
 
         /// <summary>
         ///     The name of the deployment.
         /// </summary>
-        public string Name { get; }
+        public string Name { get; private set; }
 
         /// <summary>
         ///     The id of the deployment.
         /// </summary>
-        public string Id { get; }
+        public string Id { get; private set; }
 
-        public DeploymentInfo(string projectName, string name, string id)
+        /// <summary>
+        ///     The start time of the deployment.
+        /// </summary>
+        public string StartTime { get; private set; }
+
+        /// <summary>
+        ///     The region that the deployment is in.
+        /// </summary>
+        public string Region { get; private set; }
+
+        /// <summary>
+        ///     The tags on the deployment.
+        /// </summary>
+        public List<string> Tags { get; private set; }
+
+        public Dictionary<string, long> Workers { get; private set; }
+
+        public static DeploymentInfo FromJson(string projectName, Dictionary<string, object> json)
         {
-            ProjectName = projectName;
-            Name = name;
-            Id = id;
+            var workers = (Dictionary<string, object>) json["Workers"];
+
+            return new DeploymentInfo
+            {
+                ProjectName = projectName,
+                Name = (string) json["Name"],
+                Id = (string) json["Id"],
+                StartTime = (string) json["StartTime"],
+                Region = (string) json["Region"],
+                Tags = ((List<object>) json["Tags"]).Select(str => (string) str).ToList(),
+                Workers = workers
+                    .Select(pair => (pair.Key, (long) pair.Value))
+                    .Where(pair => pair.Item2 > 0)
+                    .ToDictionary(pair => pair.Item1, pair => pair.Item2)
+            };
         }
     }
 

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
@@ -395,7 +395,7 @@ namespace Improbable.Gdk.DeploymentManager
         /// <summary>
         ///     Describes the types and counts of workers that are currently connected to this deployment.
         /// </summary>
-        public Dictionary<string, long> Workers { get; private set; }
+        public IReadOnlyDictionary<string, long> Workers { get; private set; }
 
         public static DeploymentInfo FromJson(string projectName, Dictionary<string, object> json)
         {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
@@ -380,7 +380,7 @@ namespace Improbable.Gdk.DeploymentManager
         /// <summary>
         ///     The start time of the deployment.
         /// </summary>
-        public string StartTime { get; private set; }
+        public DateTime StartTime { get; private set; }
 
         /// <summary>
         ///     The region that the deployment is in.
@@ -390,8 +390,11 @@ namespace Improbable.Gdk.DeploymentManager
         /// <summary>
         ///     The tags on the deployment.
         /// </summary>
-        public List<string> Tags { get; private set; }
+        public HashSet<string> Tags { get; private set; }
 
+        /// <summary>
+        ///     Describes the types and counts of workers that are currently connected to this deployment.
+        /// </summary>
         public Dictionary<string, long> Workers { get; private set; }
 
         public static DeploymentInfo FromJson(string projectName, Dictionary<string, object> json)
@@ -403,9 +406,9 @@ namespace Improbable.Gdk.DeploymentManager
                 ProjectName = projectName,
                 Name = (string) json["Name"],
                 Id = (string) json["Id"],
-                StartTime = (string) json["StartTime"],
+                StartTime = DateTimeOffset.FromUnixTimeSeconds((long) json["StartTime"]).DateTime,
                 Region = (string) json["Region"],
-                Tags = ((List<object>) json["Tags"]).Select(str => (string) str).ToList(),
+                Tags = new HashSet<string>(((List<object>) json["Tags"]).Select(str => (string) str)),
                 Workers = workers
                     .Select(pair => (pair.Key, (long) pair.Value))
                     .Where(pair => pair.Item2 > 0)

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -160,6 +160,8 @@ namespace Improbable.Gdk.DeploymentManager
                 }
                 else
                 {
+                    // Stop the potential infinite loop of retries.
+                    manager.Cancel();
                     Debug.LogError("Failed to authenticate with SpatialOS. Please run \"spatial auth login\" manually.");
                 }
             }
@@ -493,7 +495,7 @@ namespace Improbable.Gdk.DeploymentManager
                     dest.Tags[i] = EditorGUILayout.TextField($"Tag #{i + 1}", dest.Tags[i]);
                 }
 
-                dest.Tags.Add(EditorGUILayout.TextField($"Tag #{dest.Tags.Count + 1}", ""));
+                dest.Tags.Add(EditorGUILayout.TextField($"Tag #{dest.Tags.Count + 1}", string.Empty));
 
                 dest.Tags = dest.Tags.Where(tag => !string.IsNullOrEmpty(tag)).ToList();
             }
@@ -739,7 +741,7 @@ namespace Improbable.Gdk.DeploymentManager
         {
             if (!manager.IsActive)
             {
-                return "";
+                return string.Empty;
             }
 
             var sb = new StringBuilder();

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -91,13 +92,12 @@ namespace Improbable.Gdk.DeploymentManager
                     var error = result.UnwrapError();
 
                     Debug.LogError($"Launch of {config.Name} failed. Code: {error.Code} Message: {error.Message}");
-                    if (CatchAuthenticationError(error))
+                    if (AuthenticateIfNeeded(error))
                     {
                         postAuthTask = () => manager.LaunchImmediate(projectName, assemblyName, config);
                     }
                 }
             }
-
 
             foreach (var wrappedTask in manager.CompletedListTasks)
             {
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.DeploymentManager
 
                     Debug.LogError($"Failed to list deployments in project {wrappedTask.Context}. Code: {error.Code} Message: {error.Message}");
 
-                    if (CatchAuthenticationError(error))
+                    if (AuthenticateIfNeeded(error))
                     {
                         postAuthTask = () => manager.List(wrappedTask.Context);
                     }
@@ -134,7 +134,7 @@ namespace Improbable.Gdk.DeploymentManager
                     var error = result.UnwrapError();
 
                     Debug.LogError($"Failed to stop deployment: \"{info.Name}\". Code: {error.Code} Message: {error.Message}.");
-                    if (CatchAuthenticationError(error))
+                    if (AuthenticateIfNeeded(error))
                     {
                         postAuthTask = () => manager.Stop(wrappedTask.Context);
                     }
@@ -596,7 +596,7 @@ namespace Improbable.Gdk.DeploymentManager
                     {
                         if (foldoutState)
                         {
-                            EditorGUILayout.LabelField("Start Time", deplInfo.StartTime);
+                            EditorGUILayout.LabelField("Start Time", deplInfo.StartTime.ToString(CultureInfo.CurrentCulture));
                             EditorGUILayout.LabelField("Region", deplInfo.Region);
 
                             if (deplInfo.Workers.Count > 0)
@@ -716,7 +716,7 @@ namespace Improbable.Gdk.DeploymentManager
             }
         }
 
-        private bool CatchAuthenticationError(Ipc.Error error)
+        private bool AuthenticateIfNeeded(Ipc.Error error)
         {
             if (error.Code == Ipc.ErrorCode.Unauthenticated)
             {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -94,7 +94,7 @@ namespace Improbable.Gdk.DeploymentManager
 
                     if (TryAuthAndRetry(error))
                     {
-                        manager.Launch(cachedProjectName, assemblyName, config, TaskManager.QueueMode.ForceNext);
+                        manager.Launch(cachedProjectName, assemblyName, config, TaskManager.QueueMode.RunNext);
                     }
                     else
                     {
@@ -118,7 +118,7 @@ namespace Improbable.Gdk.DeploymentManager
 
                     if (TryAuthAndRetry(error))
                     {
-                        manager.List(wrappedTask.Context, TaskManager.QueueMode.ForceNext);
+                        manager.List(wrappedTask.Context, TaskManager.QueueMode.RunNext);
                     }
                     else
                     {
@@ -141,7 +141,7 @@ namespace Improbable.Gdk.DeploymentManager
 
                     if (TryAuthAndRetry(error))
                     {
-                        manager.Stop(wrappedTask.Context, TaskManager.QueueMode.ForceNext);
+                        manager.Stop(wrappedTask.Context, TaskManager.QueueMode.RunNext);
                     }
                     else
                     {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -61,6 +61,20 @@ namespace Improbable.Gdk.DeploymentManager
             }
 
             spinnerMaterial = new Material(Shader.Find("UI/Default"));
+
+            Application.quitting += OnExit;
+        }
+
+        private void OnDestroy()
+        {
+            OnExit();
+
+            Application.quitting -= OnExit;
+        }
+
+        private void OnExit()
+        {
+            manager.Cancel();
         }
 
         private void Update()

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Ipc.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Ipc.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace Improbable.Gdk.DeploymentManager
 {
-    public static class Ipc
+    internal static class Ipc
     {
         public enum ErrorCode : uint
         {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Ipc.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Ipc.cs
@@ -90,7 +90,7 @@ namespace Improbable.Gdk.DeploymentManager
                 {
                     var json = (Dictionary<string, object>) depl;
 
-                    return new DeploymentInfo(projectName, (string) json["Name"], (string) json["Id"]);
+                    return DeploymentInfo.FromJson(projectName, json);
                 }).ToList());
             }
             catch (InvalidCastException e)

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/TaskManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/TaskManager.cs
@@ -26,6 +26,12 @@ namespace Improbable.Gdk.DeploymentManager
             CompletedTasks.Clear();
         }
 
+        public void Cancel()
+        {
+            CurrentTask?.Cancel();
+            queuedTasks.Clear();
+        }
+
         public void Upload(AssemblyConfig config, QueueMode mode = QueueMode.Normal)
         {
             AddTask(mode, () => Assembly.UploadAsync(config));

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/TaskManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/TaskManager.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-using Improbable.Gdk.Core.Collections;
 using Improbable.Gdk.DeploymentManager.Commands;
 using UnityEditor;
-using AuthTask =
-    Improbable.Gdk.DeploymentManager.Commands.WrappedTask<Improbable.Gdk.Tools.RedirectedProcessResult, int>;
 
 namespace Improbable.Gdk.DeploymentManager
 {

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/TaskManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/TaskManager.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using Improbable.Gdk.Core.Collections;
+using Improbable.Gdk.DeploymentManager.Commands;
+using UnityEditor;
+using AuthTask =
+    Improbable.Gdk.DeploymentManager.Commands.WrappedTask<Improbable.Gdk.Tools.RedirectedProcessResult, int>;
+
+namespace Improbable.Gdk.DeploymentManager
+{
+    internal class TaskManager
+    {
+        public enum QueueMode
+        {
+            Normal,
+            ForceNext
+        }
+
+        public bool IsActive => CurrentTask != null;
+        public IWrappedTask CurrentTask { get; private set; }
+        public readonly List<IWrappedTask> CompletedTasks = new List<IWrappedTask>();
+
+        private List<Func<IWrappedTask>> queuedTasks = new List<Func<IWrappedTask>>();
+        private bool isLocked;
+        private Func<IWrappedTask> queuedAuthTask;
+
+        public void ClearResults()
+        {
+            CompletedTasks.Clear();
+        }
+
+        public void Upload(AssemblyConfig config, QueueMode mode = QueueMode.Normal)
+        {
+            AddTask(mode, () => Assembly.UploadAsync(config));
+        }
+
+        public void Launch(string projectName, string assemblyName, BaseDeploymentConfig config,
+            QueueMode mode = QueueMode.Normal)
+        {
+            AddTask(mode, () => Deployment.LaunchAsync(projectName, assemblyName, config));
+        }
+
+        public void List(string projectName, QueueMode mode = QueueMode.Normal)
+        {
+            AddTask(mode, () => Deployment.ListAsync(projectName));
+        }
+
+        public void Stop(DeploymentInfo info, QueueMode mode = QueueMode.Normal)
+        {
+            AddTask(mode, () => Deployment.StopAsync(info));
+        }
+
+        public void Auth()
+        {
+            queuedAuthTask = Authentication.Authenticate;
+        }
+
+        public void Update()
+        {
+            if (!IsActive)
+            {
+                // Always prefer the auth task over any queued t asks.
+                if (queuedAuthTask != null)
+                {
+                    CurrentTask = queuedAuthTask();
+                    queuedAuthTask = null;
+
+                    if (!isLocked)
+                    {
+                        EditorApplication.LockReloadAssemblies();
+                        isLocked = true;
+                    }
+                }
+                else if (queuedTasks.Count > 0)
+                {
+                    var queuedTask = queuedTasks[0];
+                    queuedTasks.RemoveAt(0);
+
+                    CurrentTask = queuedTask();
+
+                    if (!isLocked)
+                    {
+                        EditorApplication.LockReloadAssemblies();
+                        isLocked = true;
+                    }
+                }
+                else if (isLocked)
+                {
+                    EditorApplication.UnlockReloadAssemblies();
+                    isLocked = false;
+                }
+            }
+            else
+            {
+                if (CurrentTask.IsDone())
+                {
+                    CompletedTasks.Add(CurrentTask);
+                    CurrentTask = null;
+                }
+            }
+        }
+
+        private void AddTask(QueueMode mode, Func<IWrappedTask> closure)
+        {
+            switch (mode)
+            {
+                case QueueMode.Normal:
+                    queuedTasks.Add(closure);
+                    break;
+                case QueueMode.ForceNext:
+                    queuedTasks.Insert(0, closure);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/TaskManager.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/TaskManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2386ca0b0bc758469fd9a16c69c60d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
This PR adds the listing and stopping functionality back into the deployment launcher. We fetch more data about each deployment (start time, region, which workers are connected, and tags on the deployment) and expose a button to open the deployment in the console. 

![image](https://user-images.githubusercontent.com/13353733/57026691-47c88900-6c32-11e9-85e8-5369b1461b9d.png)

#### Tests
Tested each part of the functionality. Seemed to work and report errors properly.

#### Documentation
Coming soon

**Did you remember a changelog entry?**
Will do a big one for the _final merge_. 

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jessicafalk @jared-improbable 
