### PR TITLE
Deployment launcher handles exits properly

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -61,6 +61,20 @@ namespace Improbable.Gdk.DeploymentManager
             }
 
             spinnerMaterial = new Material(Shader.Find("UI/Default"));
+
+            Application.quitting += OnExit;
+        }
+
+        private void OnDestroy()
+        {
+            OnExit();
+
+            Application.quitting -= OnExit;
+        }
+
+        private void OnExit()
+        {
+            manager.Cancel();
         }
 
         private void Update()


### PR DESCRIPTION
#### Description
Sorry for the stacked diff, but noticed this was super simple to do with how it is currently setup.

#### Tests
Closed the window = process killed.
Closed Unity = process killed.

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
