### PR TITLE
Adding callbacks for losing player

### DIFF
--- a/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DefaultPlayState.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DefaultPlayState.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 namespace Fps
 {
     public class DefaultPlayState : DefaultState
@@ -9,6 +11,7 @@ namespace Fps
         public override void StartState()
         {
             Blackboard.ClientConnector.Worker.OnDisconnect += WorkerOnDisconnect;
+            Blackboard.ClientConnector.OnLostPlayerEntity += LostPlayerEntity;
             Manager.InGameManager.Timer.SetActive(false);
             Manager.ShowGameView();
         }
@@ -16,9 +19,15 @@ namespace Fps
         public override void ExitState()
         {
             Blackboard.ClientConnector.Worker.OnDisconnect -= WorkerOnDisconnect;
+            Blackboard.ClientConnector.OnLostPlayerEntity -= LostPlayerEntity;
         }
 
         private void WorkerOnDisconnect(string reason)
+        {
+            Owner.SetState(new DisconnectedState(Manager, Owner));
+        }
+
+        private void LostPlayerEntity()
         {
             Owner.SetState(new DisconnectedState(Manager, Owner));
         }

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DefaultPlayState.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DefaultPlayState.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 namespace Fps
 {
     public class DefaultPlayState : DefaultState

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DefaultPlayState.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DefaultPlayState.cs
@@ -27,6 +27,9 @@ namespace Fps
 
         private void LostPlayerEntity()
         {
+            Manager.ShowFrontEnd();
+            ScreenManager.SwitchToDefaultScreen();
+            Animator.SetTrigger("Disconnected");
             Owner.SetState(new DisconnectedState(Manager, Owner));
         }
     }

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DisconnectedState.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DisconnectedState.cs
@@ -1,3 +1,5 @@
+using Improbable.Gdk.Core;
+
 namespace Fps
 {
     public class DisconnectedState : DefaultState
@@ -8,6 +10,7 @@ namespace Fps
 
         public override void StartState()
         {
+            UnityObjectDestroyer.Destroy(Blackboard.ClientConnector.gameObject);
             Blackboard.ClientConnector = null;
             ScreenManager.DefaultConnectButton.enabled = true;
             ScreenManager.DefaultConnectButton.onClick.AddListener(Connect);

--- a/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DisconnectedState.cs
+++ b/workers/unity/Assets/Fps/Scripts/GameLogic/StateMachine/Default/DisconnectedState.cs
@@ -1,4 +1,4 @@
-using Improbable.Gdk.Core;
+using UnityEngine;
 
 namespace Fps
 {
@@ -10,7 +10,7 @@ namespace Fps
 
         public override void StartState()
         {
-            UnityObjectDestroyer.Destroy(Blackboard.ClientConnector.gameObject);
+            Object.Destroy(Blackboard.ClientConnector.gameObject);
             Blackboard.ClientConnector = null;
             ScreenManager.DefaultConnectButton.enabled = true;
             ScreenManager.DefaultConnectButton.onClick.AddListener(Connect);

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/AdvancedEntityPipeline.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/AdvancedEntityPipeline.cs
@@ -39,7 +39,7 @@ namespace Fps
         {
             this.worker = worker;
             this.fallback = fallback;
-            workerIdAttribute = string.Format(WorkerAttributeFormat, worker.WorkerId);
+            workerIdAttribute = EntityTemplate.GetWorkerAccessAttribute(worker.WorkerId);
             cachedAuthPlayer = Resources.Load<GameObject>(authPlayer);
             cachedNonAuthPlayer = Resources.Load<GameObject>(nonAuthPlayer);
         }

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/AdvancedEntityPipeline.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/AdvancedEntityPipeline.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Fps;
 using Improbable;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.GameObjectCreation;
@@ -24,6 +25,8 @@ public class AdvancedEntityPipeline : IEntityGameObjectCreator
     private readonly Worker worker;
 
     private readonly Dictionary<EntityId, GameObject> gameObjectsCreated = new Dictionary<EntityId, GameObject>();
+
+    public event Action OnRemovedAuthoritativePlayer;
 
     private readonly Type[] componentsToAdd =
     {
@@ -91,6 +94,12 @@ public class AdvancedEntityPipeline : IEntityGameObjectCreator
         {
             fallback.OnEntityRemoved(entityId);
             return;
+        }
+
+        // Trigger a callback when authoritative player gets removed
+        if (go.GetComponent<FpsDriver>() != null)
+        {
+            OnRemovedAuthoritativePlayer?.Invoke();
         }
 
         gameObjectsCreated.Remove(entityId);

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/AdvancedEntityPipeline.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/AdvancedEntityPipeline.cs
@@ -1,108 +1,109 @@
 ﻿using System;
 using System.Collections.Generic;
-using Fps;
 using Improbable;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.GameObjectCreation;
 using Improbable.Gdk.Movement;
 using Improbable.Gdk.StandardTypes;
 using Improbable.Gdk.Subscriptions;
-using Unity.Entities;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
-public class AdvancedEntityPipeline : IEntityGameObjectCreator
+namespace Fps
 {
-    private const string GameobjectNameFormat = "{0}(SpatialOS {1}, Worker: {2})";
-    private const string WorkerAttributeFormat = "workerId:{0}";
-    private const string PlayerMetadata = "Player";
-
-    private readonly GameObject cachedAuthPlayer;
-    private readonly GameObject cachedNonAuthPlayer;
-
-    private readonly IEntityGameObjectCreator fallback;
-    private readonly string workerIdAttribute;
-    private readonly Worker worker;
-
-    private readonly Dictionary<EntityId, GameObject> gameObjectsCreated = new Dictionary<EntityId, GameObject>();
-
-    public event Action OnRemovedAuthoritativePlayer;
-
-    private readonly Type[] componentsToAdd =
+    public class AdvancedEntityPipeline : IEntityGameObjectCreator
     {
-        typeof(Transform),
-        typeof(Rigidbody)
-    };
+        private const string GameobjectNameFormat = "{0}(SpatialOS {1}, Worker: {2})";
+        private const string WorkerAttributeFormat = "workerId:{0}";
+        private const string PlayerMetadata = "Player";
 
-    public AdvancedEntityPipeline(Worker worker, string authPlayer, string nonAuthPlayer,
-        IEntityGameObjectCreator fallback)
-    {
-        this.worker = worker;
-        this.fallback = fallback;
-        workerIdAttribute = string.Format(WorkerAttributeFormat, worker.WorkerId);
-        cachedAuthPlayer = Resources.Load<GameObject>(authPlayer);
-        cachedNonAuthPlayer = Resources.Load<GameObject>(nonAuthPlayer);
-    }
+        private readonly GameObject cachedAuthPlayer;
+        private readonly GameObject cachedNonAuthPlayer;
 
-    public void OnEntityCreated(SpatialOSEntity entity, EntityGameObjectLinker linker)
-    {
-        if (!entity.HasComponent<Metadata.Component>())
+        private readonly IEntityGameObjectCreator fallback;
+        private readonly string workerIdAttribute;
+        private readonly Worker worker;
+
+        private readonly Dictionary<EntityId, GameObject> gameObjectsCreated = new Dictionary<EntityId, GameObject>();
+
+        public event Action OnRemovedAuthoritativePlayer;
+
+        private readonly Type[] componentsToAdd =
         {
-            return;
+            typeof(Transform),
+            typeof(Rigidbody)
+        };
+
+        public AdvancedEntityPipeline(Worker worker, string authPlayer, string nonAuthPlayer,
+            IEntityGameObjectCreator fallback)
+        {
+            this.worker = worker;
+            this.fallback = fallback;
+            workerIdAttribute = string.Format(WorkerAttributeFormat, worker.WorkerId);
+            cachedAuthPlayer = Resources.Load<GameObject>(authPlayer);
+            cachedNonAuthPlayer = Resources.Load<GameObject>(nonAuthPlayer);
         }
 
-        var prefabName = entity.GetComponent<Metadata.Component>().EntityType;
-        if (prefabName.Equals(PlayerMetadata))
+        public void OnEntityCreated(SpatialOSEntity entity, EntityGameObjectLinker linker)
         {
-            var clientMovement = entity.GetComponent<ClientMovement.Component>();
-            if (entity.GetComponent<EntityAcl.Component>().ComponentWriteAcl
-                .TryGetValue(clientMovement.ComponentId, out var clientMovementWrite))
+            if (!entity.HasComponent<Metadata.Component>())
             {
-                var authority = false;
-                foreach (var attributeSet in clientMovementWrite.AttributeSet)
-                {
-                    if (attributeSet.Attribute.Contains(workerIdAttribute))
-                    {
-                        authority = true;
-                    }
-                }
-
-                var serverPosition = entity.GetComponent<ServerMovement.Component>();
-                var position = serverPosition.Latest.Position.ToVector3() + worker.Origin;
-
-                var prefab = authority ? cachedAuthPlayer : cachedNonAuthPlayer;
-                var gameObject = Object.Instantiate(prefab, position, Quaternion.identity);
-
-                gameObjectsCreated.Add(entity.SpatialOSEntityId, gameObject);
-                gameObject.name = GetGameObjectName(prefab, entity, worker);
-                linker.LinkGameObjectToSpatialOSEntity(entity.SpatialOSEntityId, gameObject, componentsToAdd);
                 return;
             }
+
+            var prefabName = entity.GetComponent<Metadata.Component>().EntityType;
+            if (prefabName.Equals(PlayerMetadata))
+            {
+                var clientMovement = entity.GetComponent<ClientMovement.Component>();
+                if (entity.GetComponent<EntityAcl.Component>().ComponentWriteAcl
+                    .TryGetValue(clientMovement.ComponentId, out var clientMovementWrite))
+                {
+                    var authority = false;
+                    foreach (var attributeSet in clientMovementWrite.AttributeSet)
+                    {
+                        if (attributeSet.Attribute.Contains(workerIdAttribute))
+                        {
+                            authority = true;
+                        }
+                    }
+
+                    var serverPosition = entity.GetComponent<ServerMovement.Component>();
+                    var position = serverPosition.Latest.Position.ToVector3() + worker.Origin;
+
+                    var prefab = authority ? cachedAuthPlayer : cachedNonAuthPlayer;
+                    var gameObject = Object.Instantiate(prefab, position, Quaternion.identity);
+
+                    gameObjectsCreated.Add(entity.SpatialOSEntityId, gameObject);
+                    gameObject.name = GetGameObjectName(prefab, entity, worker);
+                    linker.LinkGameObjectToSpatialOSEntity(entity.SpatialOSEntityId, gameObject, componentsToAdd);
+                    return;
+                }
+            }
+
+            fallback.OnEntityCreated(entity, linker);
         }
 
-        fallback.OnEntityCreated(entity, linker);
-    }
-
-    private static string GetGameObjectName(GameObject prefab, SpatialOSEntity entity, Worker worker)
-    {
-        return string.Format(GameobjectNameFormat, prefab.name, entity.SpatialOSEntityId, worker.WorkerType);
-    }
-
-    public void OnEntityRemoved(EntityId entityId)
-    {
-        if (!gameObjectsCreated.TryGetValue(entityId, out var go))
+        private static string GetGameObjectName(GameObject prefab, SpatialOSEntity entity, Worker worker)
         {
-            fallback.OnEntityRemoved(entityId);
-            return;
+            return string.Format(GameobjectNameFormat, prefab.name, entity.SpatialOSEntityId, worker.WorkerType);
         }
 
-        // Trigger a callback when authoritative player gets removed
-        if (go.GetComponent<FpsDriver>() != null)
+        public void OnEntityRemoved(EntityId entityId)
         {
-            OnRemovedAuthoritativePlayer?.Invoke();
-        }
+            if (!gameObjectsCreated.TryGetValue(entityId, out var go))
+            {
+                fallback.OnEntityRemoved(entityId);
+                return;
+            }
 
-        gameObjectsCreated.Remove(entityId);
-        Object.Destroy(go);
+            // Trigger a callback when authoritative player gets removed
+            if (go.GetComponent<FpsDriver>() != null)
+            {
+                OnRemovedAuthoritativePlayer?.Invoke();
+            }
+
+            gameObjectsCreated.Remove(entityId);
+            Object.Destroy(go);
+        }
     }
 }

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/ClientWorkerConnector.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/ClientWorkerConnector.cs
@@ -114,7 +114,7 @@ namespace Fps
 
         private void RemovingAuthoritativePlayer()
         {
-            Debug.LogError($"Removing authoritative player.");
+            Debug.LogError($"Player entity got removed while still being connected. Disconnecting...");
             OnLostPlayerEntity?.Invoke();
         }
 

--- a/workers/unity/Assets/Fps/Scripts/SetupLogic/OneTimeInitialisation.cs
+++ b/workers/unity/Assets/Fps/Scripts/SetupLogic/OneTimeInitialisation.cs
@@ -23,6 +23,7 @@ namespace Fps
 
             // Setup template to use for player on connecting client
             PlayerLifecycleConfig.CreatePlayerEntityTemplate = FpsEntityTemplates.Player;
+            PlayerLifecycleConfig.MaxNumFailedPlayerHeartbeats = 5;
         }
     }
 }


### PR DESCRIPTION
#### Description
Especially on mobile it can happen that SpatialOS thinks a worker is still connected, but the server-worker heartbeats fail at some point. When that happens we delete the player entity, but not disconnect the client leaving the client in a bad state. This PR creates some callbacks to disconnect whenever we lose the player entity and go back to the start screen.

#### Tests
running in editor by deleting player entities via the inspector.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

**Did you remember a changelog entry?**

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
