### PR TITLE
Pin shared-ci version

### DIFF
--- a/ci/bootstrap.sh
+++ b/ci/bootstrap.sh
@@ -5,14 +5,21 @@ cd "$(dirname "$0")/../"
 
 SHARED_CI_DIR="$(pwd)/.shared-ci"
 CLONE_URL="git@github.com:spatialos/gdk-for-unity-shared-ci.git"
+PINNED_SHARED_CI_VERSION=$(cat ./ci/shared-ci.pinned)
 
 # Clone the HEAD of the shared CI repo into ".shared-ci"
 
-if [[ -d "${SHARED_CI_DIR}" ]]; then
-    rm -rf "${SHARED_CI_DIR}"
-fi
+rm -rf "${SHARED_CI_DIR}"
 
-git clone --verbose --depth 1 "${CLONE_URL}" "${SHARED_CI_DIR}"
+mkdir "${SHARED_CI_DIR}"
+
+# Workaround for being unable to clone a specific commit with depth of 1.
+pushd "${SHARED_CI_DIR}"
+    git init
+    git remote add origin "${CLONE_URL}"
+    git fetch --depth 20 origin master
+    git checkout "${PINNED_SHARED_CI_VERSION}"
+popd
 
 # Clone the GDK for Unity repository
 

--- a/ci/bootstrap.sh
+++ b/ci/bootstrap.sh
@@ -9,7 +9,9 @@ PINNED_SHARED_CI_VERSION=$(cat ./ci/shared-ci.pinned)
 
 # Clone the HEAD of the shared CI repo into ".shared-ci"
 
-rm -rf "${SHARED_CI_DIR}"
+if [[ -d "${SHARED_CI_DIR}" ]]; then
+    rm -rf "${SHARED_CI_DIR}"
+fi
 
 mkdir "${SHARED_CI_DIR}"
 

--- a/ci/shared-ci.pinned
+++ b/ci/shared-ci.pinned
@@ -1,0 +1,1 @@
+93e6d876a0cd1de68a2d501dbde257530eb6faea


### PR DESCRIPTION
#### Description

This is defensive of a future change in the GDK to stop copying schema files around. Said change means that we no longer have to run `spatial prepare-for-run` in the worker build step. 

As different projects/branches now require different commits from the shared-ci repo, we need to pin which version we use.

#### Tests

- [x] copied across the pinning/cloning code from https://github.com/spatialos/gdk-for-unity/pull/953/commits/614055ea1a7aa0e35588005a125c29daefb6f4a2

#### Documentation

n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
