### PR TITLE
Marking linux builds as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Upgraded the project to be compatible with `2019.1.3f1`.
+- Marked the Linux builds for the GameLogic worker and the Simulated Player Coordinator as required.
 
 ## `0.2.2` - 2019-05-15
 

--- a/workers/unity/Assets/Fps/Config/BuildConfiguration.asset
+++ b/workers/unity/Assets/Fps/Config/BuildConfiguration.asset
@@ -71,7 +71,7 @@ MonoBehaviour:
         Required: 0
       - Options: 16384
         Enabled: 1
-        Required: 0
+        Required: 1
       - Options: 0
         Enabled: 0
         Required: 0
@@ -105,7 +105,7 @@ MonoBehaviour:
         Required: 0
       - Options: 16384
         Enabled: 1
-        Required: 0
+        Required: 1
       - Options: 0
         Enabled: 0
         Required: 0


### PR DESCRIPTION
#### Description
marked linux builds for the gamelogic worker and the simulated player coordinator worker as required to ensure that the build fails, if  you don't have linux build support installed.