### PR TITLE
Fix exception when shooting health pickups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,24 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug where shooting a health pickup throws an exception. [#212](https://github.com/spatialos/gdk-for-unity-fps-starter-project/issues/212)
+
 ## `0.2.5` - 2019-07-18
 
 ### Changed
 
-- Changed manifest to use GDK Packages with NPM instead of sideloading.
-- Upgraded to GDK for Unity version `0.2.5`
+- Changed manifest to use GDK Packages with NPM instead of sideloading. [#211](https://github.com/spatialos/gdk-for-unity-fps-starter-project/pull/211)
+- Upgraded to GDK for Unity version `0.2.5`. [#219](https://github.com/spatialos/gdk-for-unity-fps-starter-project/pull/219)
 
 ### Internal
 
-- Split the `MobileClient` build into separate `iOS` and `Android` buildkite steps.
+- Split the `MobileClient` build into separate `iOS` and `Android` buildkite steps. [#209](https://github.com/spatialos/gdk-for-unity-fps-starter-project/pull/209)
 
 ### Fixed
 
-- Fixed a bug where you had to fully uninstall and reinstall a mobile app to swap between local and cloud workflows.
+- Fixed a bug where you had to fully uninstall and reinstall a mobile app to swap between local and cloud workflows. [#218](https://github.com/spatialos/gdk-for-unity-fps-starter-project/pull/218)
 
 ## `0.2.4` - 2019-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a bug where shooting a health pickup throws an exception. [#212](https://github.com/spatialos/gdk-for-unity-fps-starter-project/issues/212)
+- Fixed a bug where shooting a health pickup throws an exception. [#220](https://github.com/spatialos/gdk-for-unity-fps-starter-project/pull/220)
 
 ## `0.2.5` - 2019-07-18
 

--- a/workers/unity/Packages/io.improbable.gdk.guns/Systems/ServerShootingSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.guns/Systems/ServerShootingSystem.cs
@@ -1,7 +1,6 @@
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Health;
 using Unity.Entities;
-using UnityEngine;
 
 namespace Improbable.Gdk.Guns
 {
@@ -24,6 +23,11 @@ namespace Improbable.Gdk.Guns
         protected override void OnUpdate()
         {
             var events = componentUpdateSystem.GetEventsReceived<ShootingComponent.Shots.Event>();
+            if (events.Count == 0)
+            {
+                return;
+            }
+
             var gunDataForEntity = GetComponentDataFromEntity<GunComponent.Component>();
 
             for (var i = 0; i < events.Count; ++i)
@@ -41,12 +45,17 @@ namespace Improbable.Gdk.Guns
                     continue;
                 }
 
+                if (!gunDataForEntity.Exists(shooterEntity))
+                {
+                    continue;
+                }
+
                 var gunComponent = gunDataForEntity[shooterEntity];
                 var damage = GunDictionary.Get(gunComponent.GunId).ShotDamage;
 
                 var modifyHealthRequest = new HealthComponent.ModifyHealth.Request(
                     new EntityId(shotInfo.EntityId),
-                    new HealthModifier()
+                    new HealthModifier
                     {
                         Amount = -damage,
                         Origin = shotInfo.HitOrigin,


### PR DESCRIPTION
#### Description

- check if gun data exists before using it
	- Quick-fix for #212 
- drive-by update to changelog

#### Tests

- shot some pickups and no more exceptions

#### Documentation

- [x] changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
