### PR TITLE
Update release QA script

### DIFF
--- a/ci/launch.sh
+++ b/ci/launch.sh
@@ -16,6 +16,12 @@ buildkite-agent artifact download "build\assembly\**\*" .
 
 uploadAssembly "${ASSEMBLY_PREFIX}" "${PROJECT_NAME}"
 
+# If the RUNTIME_VERSION env variable is already set, i.e. - through the Buildkite menu
+# then skip reading the file.
+if [[ -n $"{RUNTIME_VERSION:-}" ]]; then
+  export RUNTIME_VERSION="$(cat ../gdk-for-unity/workers/unity/Packages/io.improbable.gdk.tools/runtime.pinned)"
+fi
+
 echo "--- Launching main deployment :airplane_departure:"
 
 dotnet run -p workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj -- \
@@ -26,7 +32,8 @@ dotnet run -p workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.Deplo
     --launch_json_path cloud_launch_large.json \
     --snapshot_path snapshots/cloud.snapshot \
     --region EU \
-    --tags "dev_login"
+    --tags "dev_login" \
+    --runtime_version="${RUNTIME_VERSION}"
 
 CONSOLE_URL="https://console.improbable.io/projects/${PROJECT_NAME}/deployments/${ASSEMBLY_NAME}/overview"
 
@@ -41,6 +48,7 @@ dotnet run -p workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.Deplo
     --deployment_name "${ASSEMBLY_NAME}_sim_players" \
     --launch_json_path cloud_launch_large_sim_players.json \
     --region EU \
+    --runtime_version="${RUNTIME_VERSION}" \
     --target_deployment "${ASSEMBLY_NAME}" \
     --flag_prefix fps \
     --simulated_coordinator_worker_type SimulatedPlayerCoordinator

--- a/gdk.pinned
+++ b/gdk.pinned
@@ -1,1 +1,1 @@
-develop 19800e21d0cb65bc6c6546f7b6e4263de69249b6
+develop d3c1cf8fda5ee8fe50196cfcfb19aa33dd5a3894


### PR DESCRIPTION
As of https://github.com/spatialos/gdk-for-unity/pull/1299, the launch.sh scripts need the runtime version. This PR implements that change 