### PR TITLE
Remove deprecated network type references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- `MobileClient` now uses the `ModularKcp` networking type rather than `Kcp`. [#268](https://github.com/spatialos/gdk-for-unity-fps-starter-project/pull/268).
+
 ## `0.3.5` - 2020-04-23
 
 ### Changed

--- a/workers/unity/Assets/Fps/Scripts/WorkerConnectors/MobileWorkerConnector.cs
+++ b/workers/unity/Assets/Fps/Scripts/WorkerConnectors/MobileWorkerConnector.cs
@@ -28,16 +28,7 @@ namespace Fps.WorkerConnectors
         {
             var connParams = CreateConnectionParameters(WorkerUtils.MobileClient);
             connParams.Network.UseExternalIp = true;
-            connParams.Network.ConnectionType = NetworkConnectionType.Kcp;
-            connParams.Network.Kcp = new KcpNetworkParameters
-            {
-                // These are the last tested values
-                Heartbeat = new HeartbeatParameters
-                {
-                    IntervalMillis = 5000,
-                    TimeoutMillis = 10000
-                }
-            };
+            connParams.Network.ConnectionType = NetworkConnectionType.ModularKcp;
 
             var initializer = new MobileConnectionFlowInitializer(
                 new MobileConnectionFlowInitializer.CommandLineSettingsProvider(),


### PR DESCRIPTION
Changed `Kcp` to `ModularKcp`.

Sadly this is the end of the incredibly useful comment: 

> These are the last tested values