### PR TITLE
Enable Accelerator

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -30,6 +30,8 @@ windows: &windows
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
+  env: &windows-env
+    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 linux: &linux
   agents:
@@ -59,6 +61,8 @@ macos: &macos
         # This is designed to trap and retry failures because agent lost connection. Agent exits with -1 in this case.
       - exit_status: -1
         limit: 3
+  env: &macos-env
+    ACCELERATOR_ENDPOINT: "172.16.100.150"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
@@ -76,8 +80,6 @@ steps:
     <<: *windows
     artifact_paths:
       - logs/**/*
-    env:
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":debian: ~ annotate test results :pencil2:"
     depends_on:
@@ -99,11 +101,11 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":darwin: ~ build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -111,12 +113,12 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *macos-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
       TARGET_IOS_SDK: "simulator"
-      ACCELERATOR_ENDPOINT: "172.16.100.150"
 
   - label: ":windows: ~ build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -124,10 +126,10 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityClient il2cpp"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -135,10 +137,10 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "local"
       SCRIPTING_BACKEND: "il2cpp"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -146,10 +148,10 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build SimulatedPlayerCoordinator mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -157,7 +159,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "SimulatedPlayerCoordinator"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -69,7 +69,7 @@ steps:
   - label: ":debian: ~ lint :lint-roller:"
     command: bash -c ci/lint.sh
     <<: *linux
-    
+
   - label: ":windows: ~ test"
     id: "test"
     command: bash -c ci/test.sh
@@ -78,10 +78,10 @@ steps:
       - logs/**/*
 
   - label: ":debian: ~ annotate test results :pencil2:"
-    depends_on: 
+    depends_on:
       - step: "test"
         allow_failure: true
-    plugins: 
+    plugins:
       - improbable/test-summary#d7289cac8297018fd1b452dcf828979307b3ebc6:
           inputs:
             - label: ":octagonal_sign: Test failures "

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -76,6 +76,8 @@ steps:
     <<: *windows
     artifact_paths:
       - logs/**/*
+    env:
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":debian: ~ annotate test results :pencil2:"
     depends_on:
@@ -101,6 +103,7 @@ steps:
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":darwin: ~ build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -113,6 +116,7 @@ steps:
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
       TARGET_IOS_SDK: "simulator"
+      ACCELERATOR_ENDPOINT: "172.16.100.150"
 
   - label: ":windows: ~ build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -123,6 +127,7 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityClient il2cpp"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -133,6 +138,7 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "local"
       SCRIPTING_BACKEND: "il2cpp"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -143,6 +149,7 @@ steps:
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build SimulatedPlayerCoordinator mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -153,3 +160,4 @@ steps:
       WORKER_TYPE: "SimulatedPlayerCoordinator"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -7,7 +7,7 @@
 # You may find the example pipeline steps listed here helpful: https://buildkite.com/docs/pipelines/defining-steps#example-pipeline but please
 #  note that the setup is already done, so you should not manually adjust anything through the BuildKite interface.
 #
-common: &common
+windows: &windows
   agents:
     - "capable_of_building=gdk-for-unity"
     - "environment=production"
@@ -30,6 +30,8 @@ common: &common
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
+  env: &windows-env
+    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
@@ -37,77 +39,75 @@ common: &common
 steps:
   - label: "test"
     command: bash -c ci/test.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
-    env:
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build :android:"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build SimulatedPlayerCoordinator mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "SimulatedPlayerCoordinator"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
   - wait
   - label: Launch deployments
     command: bash -c ci/launch.sh
-    <<: *common
+    <<: *windows
     env:
       ASSEMBLY_PREFIX: "fps"
       PROJECT_NAME: "unity_gdk"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -40,6 +40,8 @@ steps:
     <<: *common
     artifact_paths:
       - logs/**/*
+    env:
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build :android:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -52,6 +54,7 @@ steps:
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -64,6 +67,7 @@ steps:
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -75,6 +79,7 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -86,6 +91,7 @@ steps:
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build SimulatedPlayerCoordinator mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -97,6 +103,7 @@ steps:
       WORKER_TYPE: "SimulatedPlayerCoordinator"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
   - wait
   - label: Launch deployments
     command: bash -c ci/launch.sh

--- a/ci/shared-ci.pinned
+++ b/ci/shared-ci.pinned
@@ -1,1 +1,1 @@
-accelerator 8ca3c40
+master f802ed7

--- a/ci/shared-ci.pinned
+++ b/ci/shared-ci.pinned
@@ -1,1 +1,1 @@
-accelerator 72c6c04
+accelerator 8ca3c40

--- a/ci/shared-ci.pinned
+++ b/ci/shared-ci.pinned
@@ -1,1 +1,1 @@
-master 7980ef5db74d8db47c0f683378a38d64accd2c0a 
+accelerator 72c6c04

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -10,6 +10,8 @@ cd "$(dirname "$0")/../"
 
 source .shared-ci/scripts/pinned-tools.sh
 
+ACCELERATOR_ARGS=${ACCELERATOR_ENDPOINT:+-enableCacheServer -cacheServerEndpoint "${ACCELERATOR_ENDPOINT}"}
+
 PROJECT_DIR="$(pwd)"
 mkdir -p "${PROJECT_DIR}/logs/"
 
@@ -24,5 +26,6 @@ pushd "workers/unity"
         -runEditorTests \
         -logfile "${PROJECT_DIR}/logs/unity-editmode-test-run.log" \
         -editorTestsResultFile "${EDITMODE_TEST_RESULTS_FILE}" \
-        -editorTestsFilter Fps
+        -editorTestsFilter Fps \
+        "${ACCELERATOR_ARGS}"
 popd

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/../"
 
 source .shared-ci/scripts/pinned-tools.sh
 
-ACCELERATOR_ARGS=${ACCELERATOR_ENDPOINT:+-enableCacheServer -cacheServerEndpoint "${ACCELERATOR_ENDPOINT}"}
+ACCELERATOR_ARGS=$(getAcceleratorArgs)
 
 PROJECT_DIR="$(pwd)"
 mkdir -p "${PROJECT_DIR}/logs/"


### PR DESCRIPTION
#### Description

Provides `ACCELERATOR_ENDPOINT` argument to agents and provides the relevant arguments to use either the local/cloud Accelerators for mac/windows agents.

Depends on https://github.com/spatialos/gdk-for-unity-shared-ci/pull/72

#### Tests

Ran the pipeline. Multiple times.

#### Documentation

n/a
